### PR TITLE
Add access to lambda to s3 uploads bucket v2

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -71,3 +71,15 @@ data "terraform_remote_state" "process_jobs_service" {
     profile = var.aws_account
   }
 }
+
+# Import Upload service for v2 bucket
+data "terraform_remote_state" "upload_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/upload-service-v2/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -204,6 +204,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn}/*",
+      data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
     ]
   }
 


### PR DESCRIPTION
Add S3 upload bucket permissions to restore service. TF output:

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last
"terraform apply":

  # module.packages_service.aws_iam_role.packages_service_lambda_role has changed
  ~ resource "aws_iam_role" "packages_service_lambda_role" {
        id                    = "dev-packages-service-lambda-role-use1"
        name                  = "dev-packages-service-lambda-role-use1"
      + role_last_used        = [
          + {
              + last_used_date = "2023-05-16T17:11:04Z"
              + region         = "us-east-1"
            },
        ]
        tags                  = {}
        # (9 unchanged attributes hidden)
    }

  # module.packages_service.aws_iam_role.restore_package_lambda_role has changed
  ~ resource "aws_iam_role" "restore_package_lambda_role" {
        id                    = "dev-restore-package-lambda-role-use1"
        name                  = "dev-restore-package-lambda-role-use1"
      + role_last_used        = [
          + {
              + last_used_date = "2023-05-16T17:20:19Z"
              + region         = "us-east-1"
            },
        ]
        tags                  = {}
        # (9 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.packages_service.aws_iam_policy.restore_package_lambda_iam_policy will be updated in-place
  ~ resource "aws_iam_policy" "restore_package_lambda_iam_policy" {
        id        = "arn:aws:iam::941165240011:policy/dev-restore-package-lambda-iam-policy-use1"
        name      = "dev-restore-package-lambda-iam-policy-use1"
      ~ policy    = jsonencode(
          ~ {
              ~ Statement = [
                    # (4 unchanged elements hidden)
                    {
                        Action   = [
                            "dynamodb:BatchWriteItem",
                            "dynamodb:BatchGetItem",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:dynamodb:us-east-1:941165240011:table/dev-delete-job-service-use1/*",
                            "arn:aws:dynamodb:us-east-1:941165240011:table/dev-delete-job-service-use1",
                        ]
                        Sid      = "RestorePackageLambdaAccessToDynamoDB"
                    },
                  ~ {
                      ~ Resource = [
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1/*",
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1",
                            "arn:aws:s3:::pennsieve-dev-storage-use1/*",
                            # (3 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.packages_service.aws_lambda_function.restore_package_lambda will be updated in-place
  ~ resource "aws_lambda_function" "restore_package_lambda" {
        id                             = "dev-restore-package-lambda-use1"
      ~ last_modified                  = "2023-04-07T21:01:38.000+0000" -> (known after apply)
      ~ s3_key                         = "packages-service/restore-package-48-1b57290.zip" -> "packages-service/restore-package-test.zip"
        tags                           = {}
        # (22 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }

  # module.packages_service.aws_lambda_function.service_lambda will be updated in-place
  ~ resource "aws_lambda_function" "service_lambda" {
        id                             = "dev-packages-service-lambda-use1"
      ~ last_modified                  = "2023-04-07T21:01:38.000+0000" -> (known after apply)
      ~ s3_key                         = "packages-service/packages-service-48-1b57290.zip" -> "packages-service/packages-service-test.zip"
        tags                           = {}
        # (22 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```