### PR TITLE
Send package restore events to ChangeLog

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,16 +3,16 @@ module github.com/pennsieve/packages-service/api
 go 1.18
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.17.5
+	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.14
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.14
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.7
-	github.com/pennsieve/pennsieve-go-core v1.2.3
+	github.com/pennsieve/pennsieve-go-core v1.4.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )
@@ -21,8 +21,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.14.4 // indirect

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.7
-	github.com/pennsieve/pennsieve-go-core v1.4.7
+	github.com/pennsieve/pennsieve-go-core v1.4.8
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,6 @@
-github.com/aws/aws-sdk-go-v2 v1.17.5 h1:TzCUW1Nq4H8Xscph5M/skINUitxM5UBAyvm2s7XBzL4=
 github.com/aws/aws-sdk-go-v2 v1.17.5/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.17.8 h1:GMupCNNI7FARX27L7GjCJM8NgivWbRgpjNI/hOQjFS8=
+github.com/aws/aws-sdk-go-v2 v1.17.8/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.18.14 h1:rI47jCe0EzuJlAO5ptREe3LIBAyP5c7gR3wjyYVjuOM=
@@ -12,10 +13,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 h1:Kbiv9PGnQfG/imNI4L/hey
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23/go.mod h1:mOtmAg65GT1HIL/HT/PynwPbS+UG0BgCZ6vhkPqnxWo=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 h1:xTuoSBz6RDIzDb8kqveEdpYUmgksxYNFeNKSYUATM4s=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7/go.mod h1:x9SeCjHqRHARRCh05Krdd3Ywmqf6cd9BtHAPN/2VYo0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 h1:9/aKwwus0TQxppPXFmf010DFrE+ssSbzroLVYINA+xE=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29/go.mod h1:Dip3sIGv485+xerzVv24emnjX5Sg88utCL8fwGmCeWg=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 h1:b/Vn141DBuLVgXbhRWIrl9g+ww7G+ScV5SzniWR13jQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 h1:dpbVNUjczQ8Ae3QKHbpHBpfvaVkRdesxpTOe9pTouhU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32/go.mod h1:RudqOgadTWdcS3t/erPQo24pcVEoYyqj/kKW5Vya21I=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23/go.mod h1:mr6c4cHC+S/MMkrjtSlG4QA36kOznDep+0fga5L/fGQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 h1:QH2kOS3Ht7x+u0gHCh06CXL/h6G8LQJFpZfFBYBNboo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26/go.mod h1:vq86l7956VgFr0/FWQ2BWnK07QC3WYsepKzy33qqY5U=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 h1:IVx9L7YFhpPq0tTnGo8u8TpluFu7nAn9X3sUDMb11c0=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30/go.mod h1:vsbq62AOBwQ1LJ/GWKFxX8beUEYeRp/Agitrxee2/qM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 h1:QdxdY43AiwsqG/VAqHA7bIVSm3rKr8/p9i05ydA0/RM=
@@ -36,8 +39,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23 h1:qc+RW0WWZ2KAp
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23/go.mod h1:FJhZWVWBCcgAF8jbep7pxQ1QUsjzTwa9tvEXGw2TDRo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4 h1:0eeEl2lyZkZPhPCt9ggIr3PbCbvae3vfggTkeqJ4O98=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4/go.mod h1:Dze3kNt4T+Dgb8YCfuIFSBLmE6hadKNxqfdF0Xmqz1I=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4 h1:8bI15PB1gxNcW53Dx3DVPZltmRiNQbtEsCtHXabNYMc=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4/go.mod h1:DVY5QFIndM5hWkrO+9lK4EN7mJUrttvpbbYcu2/id1Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7 h1:j94pkW1q8FJWSfHKLC8Hz8aknKVXE5DxICrkuWz1V6Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7/go.mod h1:w058QQWcK1MLEnIrD0DmkQtSvC1pLY0EWRQsPXPWppM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3 h1:bUeZTWfF1vBdZnoNnnq70rB/CzdZD7NR2Jg2Ax+rvjA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3/go.mod h1:jtLIhd+V+lft6ktxpItycqHqiVXrPIRjWIsFIlzMriw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.3 h1:G/+7NUi+q+H0LG3v32jfV4OkaQIcpI92g0owbXKk6NY=
@@ -59,8 +62,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.2.3 h1:XZhOLmReYxE0Pw7WRDpbRKcqrDZYzk1pB7FusEiktDQ=
-github.com/pennsieve/pennsieve-go-core v1.2.3/go.mod h1:uphYOoJUb8tlj6/FvgcXTYKNSuuI2ksy9wZnTQVLdoA=
+github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
+github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/api/go.sum
+++ b/api/go.sum
@@ -62,8 +62,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
-github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
+github.com/pennsieve/pennsieve-go-core v1.4.8 h1:hqu0y9ISYLyvC3zLzeYoBu9XEMyR35cFMdJJDcDwLxQ=
+github.com/pennsieve/pennsieve-go-core v1.4.8/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/api/models/restore.go
+++ b/api/models/restore.go
@@ -7,6 +7,7 @@ import (
 
 type RestoreRequest struct {
 	NodeIds []string `json:"nodeIds"`
+	UserId  string   `json:"userId"`
 }
 
 type RestoreResponse struct {
@@ -30,6 +31,7 @@ type RestorePackageInfo struct {
 type RestorePackageMessage struct {
 	OrgId     int                `json:"orgId"`
 	DatasetId int64              `json:"datasetId"`
+	UserId    string             `json:"userId"`
 	Package   RestorePackageInfo `json:"package"`
 }
 
@@ -41,8 +43,8 @@ func NewRestorePackageInfo(p *pgdb.Package) RestorePackageInfo {
 	return restoreInfo
 }
 
-func NewRestorePackageMessage(orgId int, datasetId int64, toBeRestored *pgdb.Package) RestorePackageMessage {
+func NewRestorePackageMessage(orgId int, datasetId int64, userId string, toBeRestored *pgdb.Package) RestorePackageMessage {
 	restoreInfo := NewRestorePackageInfo(toBeRestored)
-	queueMessage := RestorePackageMessage{OrgId: orgId, DatasetId: datasetId, Package: restoreInfo}
+	queueMessage := RestorePackageMessage{OrgId: orgId, DatasetId: datasetId, UserId: userId, Package: restoreInfo}
 	return queueMessage
 }

--- a/api/models/restore_test.go
+++ b/api/models/restore_test.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnmarshallRestoreRequest(t *testing.T) {
+	packageId := "N:package:1234"
+	body := fmt.Sprintf(`{"nodeIds": [%q]}`, packageId)
+	var request RestoreRequest
+	err := json.Unmarshal([]byte(body), &request)
+	if assert.NoError(t, err) {
+		assert.Len(t, request.NodeIds, 1)
+		assert.Equal(t, packageId, request.NodeIds[0])
+		assert.Empty(t, request.UserId)
+	}
+}

--- a/api/service/service.go
+++ b/api/service/service.go
@@ -67,7 +67,7 @@ func (s *packagesService) RestorePackages(ctx context.Context, datasetId string,
 			return nil
 		}
 		for _, r := range restoring {
-			queueMessage := models.NewRestorePackageMessage(s.OrgId, datasetIntId, r)
+			queueMessage := models.NewRestorePackageMessage(s.OrgId, datasetIntId, request.UserId, r)
 			if err = s.QueueStore.SendRestorePackage(ctx, queueMessage); err != nil {
 				// This will roll back Tx even though it's not a DB action.
 				return err

--- a/api/store/restore/changelog.go
+++ b/api/store/restore/changelog.go
@@ -1,0 +1,67 @@
+package restore
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/google/uuid"
+	"github.com/pennsieve/packages-service/api/logging"
+	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
+	"os"
+	"time"
+)
+
+type SQSChangelogStore struct {
+	Client *changelog.Client
+	Queue  string
+}
+
+func NewSQSChangelogStore(sqsClient *sqs.Client) *SQSChangelogStore {
+	jobsQueueURL := os.Getenv("JOBS_QUEUE_ID")
+	return &SQSChangelogStore{Client: changelog.NewClient(*sqsClient, jobsQueueURL), Queue: jobsQueueURL}
+}
+
+func (s *SQSChangelogStore) WithLogging(log *logging.Log) ChangelogStore {
+	return &sqsChangelogStore{
+		SQSChangelogStore: s,
+		Log:               log,
+	}
+}
+
+type sqsChangelogStore struct {
+	*SQSChangelogStore
+	*logging.Log
+}
+
+type ChangelogStore interface {
+	LogRestores(ctx context.Context, orgId, datasetId int64, userId string, changelogEvents []changelog.PackageRestoreEvent) error
+	logging.Logger
+}
+
+func (s *sqsChangelogStore) LogRestores(ctx context.Context, orgId, datasetId int64, userId string, changelogEvents []changelog.PackageRestoreEvent) error {
+	events := make([]changelog.Event, len(changelogEvents))
+	now := time.Now()
+	for i, e := range changelogEvents {
+		events[i] = changelog.Event{
+			EventType:   changelog.RestorePackage,
+			EventDetail: e,
+			Timestamp:   now,
+		}
+	}
+	params := changelog.MessageParams{
+		OrganizationId: orgId,
+		DatasetId:      datasetId,
+		UserId:         userId,
+		Events:         events,
+		TraceId:        uuid.NewString(),
+		Id:             uuid.NewString(),
+	}
+
+	message := changelog.Message{
+		DatasetChangelogEventJob: params,
+	}
+	if err := s.Client.EmitEvents(ctx, message); err != nil {
+		return fmt.Errorf("api/store/restore error sending restore changelog events to queue %s: %w", s.Queue, err)
+	}
+	return nil
+}

--- a/api/store/test.go
+++ b/api/store/test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/google/uuid"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
@@ -135,7 +136,7 @@ func (n NoLogger) LogInfo(_ ...any) {}
 
 func (n NoLogger) LogInfoWithFields(_ log.Fields, _ ...any) {}
 
-func GetTestAWSConfig(t *testing.T) aws.Config {
+func GetTestAWSConfig(t *testing.T, mockSqsUrl string) aws.Config {
 	awsKey := os.Getenv("TEST_AWS_KEY")
 	awsSecret := os.Getenv("TEST_AWS_SECRET")
 	minioURL := os.Getenv("MINIO_URL")
@@ -148,6 +149,8 @@ func GetTestAWSConfig(t *testing.T) aws.Config {
 				return aws.Endpoint{URL: minioURL, HostnameImmutable: true}, nil
 			} else if service == dynamodb.ServiceID {
 				return aws.Endpoint{URL: dynamodbURL}, nil
+			} else if service == sqs.ServiceID {
+				return aws.Endpoint{URL: mockSqsUrl}, nil
 			}
 			return aws.Endpoint{}, fmt.Errorf("unknown test endpoint requested for service: %s", service)
 		})))

--- a/dockertest.env
+++ b/dockertest.env
@@ -6,4 +6,5 @@ PENNSIEVE_DB=postgres
 POSTGRES_SSL_MODE=disable
 # dynamodb config
 DELETE_RECORD_DYNAMODB_TABLE_NAME=TestDeleteRecords
-
+# sqs config
+JOBS_QUEUE_ID=TestJobsQueueUrl

--- a/lambda/restore/go.mod
+++ b/lambda/restore/go.mod
@@ -6,14 +6,14 @@ replace github.com/pennsieve/packages-service/api => ../../api
 
 require (
 	github.com/aws/aws-lambda-go v1.38.0
-	github.com/aws/aws-sdk-go-v2 v1.17.5
+	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.14
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.14
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4
 	github.com/google/uuid v1.3.0
 	github.com/pennsieve/packages-service/api v0.0.0-00010101000000-000000000000
-	github.com/pennsieve/pennsieve-go-core v1.2.5
+	github.com/pennsieve/pennsieve-go-core v1.4.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )
@@ -23,8 +23,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.14.4 // indirect
@@ -33,7 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.4 // indirect

--- a/lambda/restore/go.mod
+++ b/lambda/restore/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4
 	github.com/google/uuid v1.3.0
 	github.com/pennsieve/packages-service/api v0.0.0-00010101000000-000000000000
-	github.com/pennsieve/pennsieve-go-core v1.4.7
+	github.com/pennsieve/pennsieve-go-core v1.4.8
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/lambda/restore/go.sum
+++ b/lambda/restore/go.sum
@@ -1,7 +1,8 @@
 github.com/aws/aws-lambda-go v1.38.0 h1:4CUdxGzvuQp0o8Zh7KtupB9XvCiiY8yKqJtzco+gsDw=
 github.com/aws/aws-lambda-go v1.38.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
-github.com/aws/aws-sdk-go-v2 v1.17.5 h1:TzCUW1Nq4H8Xscph5M/skINUitxM5UBAyvm2s7XBzL4=
 github.com/aws/aws-sdk-go-v2 v1.17.5/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.17.8 h1:GMupCNNI7FARX27L7GjCJM8NgivWbRgpjNI/hOQjFS8=
+github.com/aws/aws-sdk-go-v2 v1.17.8/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.18.14 h1:rI47jCe0EzuJlAO5ptREe3LIBAyP5c7gR3wjyYVjuOM=
@@ -14,10 +15,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 h1:Kbiv9PGnQfG/imNI4L/hey
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23/go.mod h1:mOtmAg65GT1HIL/HT/PynwPbS+UG0BgCZ6vhkPqnxWo=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 h1:xTuoSBz6RDIzDb8kqveEdpYUmgksxYNFeNKSYUATM4s=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7/go.mod h1:x9SeCjHqRHARRCh05Krdd3Ywmqf6cd9BtHAPN/2VYo0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 h1:9/aKwwus0TQxppPXFmf010DFrE+ssSbzroLVYINA+xE=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29/go.mod h1:Dip3sIGv485+xerzVv24emnjX5Sg88utCL8fwGmCeWg=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 h1:b/Vn141DBuLVgXbhRWIrl9g+ww7G+ScV5SzniWR13jQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 h1:dpbVNUjczQ8Ae3QKHbpHBpfvaVkRdesxpTOe9pTouhU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32/go.mod h1:RudqOgadTWdcS3t/erPQo24pcVEoYyqj/kKW5Vya21I=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23/go.mod h1:mr6c4cHC+S/MMkrjtSlG4QA36kOznDep+0fga5L/fGQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 h1:QH2kOS3Ht7x+u0gHCh06CXL/h6G8LQJFpZfFBYBNboo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26/go.mod h1:vq86l7956VgFr0/FWQ2BWnK07QC3WYsepKzy33qqY5U=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 h1:IVx9L7YFhpPq0tTnGo8u8TpluFu7nAn9X3sUDMb11c0=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30/go.mod h1:vsbq62AOBwQ1LJ/GWKFxX8beUEYeRp/Agitrxee2/qM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 h1:QdxdY43AiwsqG/VAqHA7bIVSm3rKr8/p9i05ydA0/RM=
@@ -38,8 +41,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23 h1:qc+RW0WWZ2KAp
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23/go.mod h1:FJhZWVWBCcgAF8jbep7pxQ1QUsjzTwa9tvEXGw2TDRo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4 h1:0eeEl2lyZkZPhPCt9ggIr3PbCbvae3vfggTkeqJ4O98=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4/go.mod h1:Dze3kNt4T+Dgb8YCfuIFSBLmE6hadKNxqfdF0Xmqz1I=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4 h1:8bI15PB1gxNcW53Dx3DVPZltmRiNQbtEsCtHXabNYMc=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4/go.mod h1:DVY5QFIndM5hWkrO+9lK4EN7mJUrttvpbbYcu2/id1Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7 h1:j94pkW1q8FJWSfHKLC8Hz8aknKVXE5DxICrkuWz1V6Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7/go.mod h1:w058QQWcK1MLEnIrD0DmkQtSvC1pLY0EWRQsPXPWppM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3 h1:bUeZTWfF1vBdZnoNnnq70rB/CzdZD7NR2Jg2Ax+rvjA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3/go.mod h1:jtLIhd+V+lft6ktxpItycqHqiVXrPIRjWIsFIlzMriw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.3 h1:G/+7NUi+q+H0LG3v32jfV4OkaQIcpI92g0owbXKk6NY=
@@ -61,8 +64,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.2.5 h1:Sf1REdh9YS06un/btthVV7X+RAYfqQ9nwfH6ZZDKwWk=
-github.com/pennsieve/pennsieve-go-core v1.2.5/go.mod h1:uphYOoJUb8tlj6/FvgcXTYKNSuuI2ksy9wZnTQVLdoA=
+github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
+github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/lambda/restore/go.sum
+++ b/lambda/restore/go.sum
@@ -64,8 +64,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
-github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
+github.com/pennsieve/pennsieve-go-core v1.4.8 h1:hqu0y9ISYLyvC3zLzeYoBu9XEMyR35cFMdJJDcDwLxQ=
+github.com/pennsieve/pennsieve-go-core v1.4.8/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/lambda/restore/handler/file_test.go
+++ b/lambda/restore/handler/file_test.go
@@ -108,7 +108,7 @@ func TestRestoreName(t *testing.T) {
 		db.ExecSQLFile("restore-package-name-test.sql")
 		sqlFactory := store.NewPostgresStoreFactory(db.DB)
 		ctx := context.Background()
-		messageHandler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil))
+		messageHandler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil))
 		restoreInfo := models.RestorePackageInfo{
 			Id:     d.id,
 			NodeId: d.nodeId,
@@ -153,7 +153,7 @@ func TestRestoreName_ConflictWithDeletedFile(t *testing.T) {
 
 	sqlFactory := store.NewPostgresStoreFactory(db.DB)
 	ctx := context.Background()
-	handler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil))
+	handler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil))
 	originalName := "root-dir"
 	restoreInfo1 := models.RestorePackageInfo{
 		Id:     5,

--- a/lambda/restore/handler/folder.go
+++ b/lambda/restore/handler/folder.go
@@ -30,12 +30,12 @@ func (h *MessageHandler) handleFolderPackage(ctx context.Context, orgId int, dat
 
 		// restore ancestors names
 		for _, a := range ancestors {
-			if err := h.restoreName(ctx, a, sqlStore); err != nil {
+			if _, err := h.restoreName(ctx, a, sqlStore); err != nil {
 				return h.errorf("error restoring name of ancestor %s of %s: %w", a.NodeId, restoreInfo.NodeId, err)
 			}
 		}
 		// restore name
-		err = h.restoreName(ctx, restoreInfo, sqlStore)
+		_, err = h.restoreName(ctx, restoreInfo, sqlStore)
 		if err != nil {
 			return h.errorf("error restoring name of %s: %w", restoreInfo.NodeId, err)
 		}
@@ -48,7 +48,7 @@ func (h *MessageHandler) handleFolderPackage(ctx context.Context, orgId int, dat
 		for _, p := range restoring {
 			sqlStore.LogDebugWithFields(log.Fields{"nodeId": p.NodeId, "state": p.PackageState}, "restoring descendant package name")
 			descRestoreInfo := models.NewRestorePackageInfo(p)
-			err = h.restoreName(ctx, descRestoreInfo, sqlStore)
+			_, err = h.restoreName(ctx, descRestoreInfo, sqlStore)
 			if err != nil {
 				return h.errorf("error restoring descendant %s of %s: %w", p.NodeId, restoreInfo.NodeId, err)
 			}

--- a/lambda/restore/main.go
+++ b/lambda/restore/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/google/uuid"
 	"github.com/pennsieve/packages-service/restore/handler"
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
@@ -48,6 +49,7 @@ func init() {
 
 	handler.S3Client = s3.NewFromConfig(cfg)
 	handler.DyDBClient = dynamodb.NewFromConfig(cfg)
+	handler.SQSClient = sqs.NewFromConfig(cfg)
 }
 
 func main() {

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -7,22 +7,22 @@ replace github.com/pennsieve/packages-service/api => ../../api
 require (
 	github.com/aws/aws-lambda-go v1.34.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.14
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7
 	github.com/pennsieve/packages-service/api v0.0.0
-	github.com/pennsieve/pennsieve-go-core v1.2.3
+	github.com/pennsieve/pennsieve-go-core v1.4.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.17.5 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.17.8 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.4 // indirect

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.14
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7
 	github.com/pennsieve/packages-service/api v0.0.0
-	github.com/pennsieve/pennsieve-go-core v1.4.7
+	github.com/pennsieve/pennsieve-go-core v1.4.8
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -1,7 +1,8 @@
 github.com/aws/aws-lambda-go v1.34.1 h1:M3a/uFYBjii+tDcOJ0wL/WyFi2550FHoECdPf27zvOs=
 github.com/aws/aws-lambda-go v1.34.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
-github.com/aws/aws-sdk-go-v2 v1.17.5 h1:TzCUW1Nq4H8Xscph5M/skINUitxM5UBAyvm2s7XBzL4=
 github.com/aws/aws-sdk-go-v2 v1.17.5/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.17.8 h1:GMupCNNI7FARX27L7GjCJM8NgivWbRgpjNI/hOQjFS8=
+github.com/aws/aws-sdk-go-v2 v1.17.8/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.18.14 h1:rI47jCe0EzuJlAO5ptREe3LIBAyP5c7gR3wjyYVjuOM=
@@ -14,10 +15,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 h1:Kbiv9PGnQfG/imNI4L/hey
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23/go.mod h1:mOtmAg65GT1HIL/HT/PynwPbS+UG0BgCZ6vhkPqnxWo=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7 h1:xTuoSBz6RDIzDb8kqveEdpYUmgksxYNFeNKSYUATM4s=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.7/go.mod h1:x9SeCjHqRHARRCh05Krdd3Ywmqf6cd9BtHAPN/2VYo0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 h1:9/aKwwus0TQxppPXFmf010DFrE+ssSbzroLVYINA+xE=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29/go.mod h1:Dip3sIGv485+xerzVv24emnjX5Sg88utCL8fwGmCeWg=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 h1:b/Vn141DBuLVgXbhRWIrl9g+ww7G+ScV5SzniWR13jQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 h1:dpbVNUjczQ8Ae3QKHbpHBpfvaVkRdesxpTOe9pTouhU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32/go.mod h1:RudqOgadTWdcS3t/erPQo24pcVEoYyqj/kKW5Vya21I=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23/go.mod h1:mr6c4cHC+S/MMkrjtSlG4QA36kOznDep+0fga5L/fGQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 h1:QH2kOS3Ht7x+u0gHCh06CXL/h6G8LQJFpZfFBYBNboo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26/go.mod h1:vq86l7956VgFr0/FWQ2BWnK07QC3WYsepKzy33qqY5U=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30 h1:IVx9L7YFhpPq0tTnGo8u8TpluFu7nAn9X3sUDMb11c0=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.30/go.mod h1:vsbq62AOBwQ1LJ/GWKFxX8beUEYeRp/Agitrxee2/qM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.21 h1:QdxdY43AiwsqG/VAqHA7bIVSm3rKr8/p9i05ydA0/RM=
@@ -38,8 +41,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23 h1:qc+RW0WWZ2KAp
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.23/go.mod h1:FJhZWVWBCcgAF8jbep7pxQ1QUsjzTwa9tvEXGw2TDRo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4 h1:0eeEl2lyZkZPhPCt9ggIr3PbCbvae3vfggTkeqJ4O98=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.4/go.mod h1:Dze3kNt4T+Dgb8YCfuIFSBLmE6hadKNxqfdF0Xmqz1I=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4 h1:8bI15PB1gxNcW53Dx3DVPZltmRiNQbtEsCtHXabNYMc=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.20.4/go.mod h1:DVY5QFIndM5hWkrO+9lK4EN7mJUrttvpbbYcu2/id1Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7 h1:j94pkW1q8FJWSfHKLC8Hz8aknKVXE5DxICrkuWz1V6Y=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.20.7/go.mod h1:w058QQWcK1MLEnIrD0DmkQtSvC1pLY0EWRQsPXPWppM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3 h1:bUeZTWfF1vBdZnoNnnq70rB/CzdZD7NR2Jg2Ax+rvjA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3/go.mod h1:jtLIhd+V+lft6ktxpItycqHqiVXrPIRjWIsFIlzMriw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.3 h1:G/+7NUi+q+H0LG3v32jfV4OkaQIcpI92g0owbXKk6NY=
@@ -61,8 +64,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.2.3 h1:XZhOLmReYxE0Pw7WRDpbRKcqrDZYzk1pB7FusEiktDQ=
-github.com/pennsieve/pennsieve-go-core v1.2.3/go.mod h1:uphYOoJUb8tlj6/FvgcXTYKNSuuI2ksy9wZnTQVLdoA=
+github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
+github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -64,8 +64,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.4.7 h1:bRemvhxS1ALhDWNf7SmGCHi/cKxokEbBtQ0GQh4mhSE=
-github.com/pennsieve/pennsieve-go-core v1.4.7/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
+github.com/pennsieve/pennsieve-go-core v1.4.8 h1:hqu0y9ISYLyvC3zLzeYoBu9XEMyR35cFMdJJDcDwLxQ=
+github.com/pennsieve/pennsieve-go-core v1.4.8/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/lambda/service/handler/restore.go
+++ b/lambda/service/handler/restore.go
@@ -38,6 +38,7 @@ func (h *RestoreHandler) post(ctx context.Context) (*events.APIGatewayV2HTTPResp
 		msg := fmt.Sprintf("unable to unmarshall request body [%s] as RestoreRequest: %v", h.body, err)
 		return h.logAndBuildError(msg, http.StatusBadRequest), nil
 	}
+	request.UserId = h.claims.UserClaim.NodeId
 	response, err := h.packagesService.RestorePackages(ctx, datasetId, request)
 	if err == nil {
 		h.logger.Info("Returning OK")

--- a/lambda/service/handler/root_test.go
+++ b/lambda/service/handler/root_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pennsieve/packages-service/api/models"
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"net/http"
@@ -43,7 +44,7 @@ func TestRestoreRoute(t *testing.T) {
 
 	claims := authorizer.Claims{
 		DatasetClaim: dataset.Claim{
-			Role:   dataset.Editor,
+			Role:   role.Editor,
 			NodeId: expectedDatasetID,
 			IntId:  1234,
 		}}
@@ -71,7 +72,7 @@ func TestRestoreRouteUnauthorized(t *testing.T) {
 
 	claims := authorizer.Claims{
 		DatasetClaim: dataset.Claim{
-			Role:   dataset.Viewer,
+			Role:   role.Viewer,
 			NodeId: expectedDatasetID,
 			IntId:  1234,
 		}}
@@ -107,7 +108,7 @@ func TestTrashcanRouteHandledErrors(t *testing.T) {
 		mockService := new(MockPackagesService)
 		claims := authorizer.Claims{
 			DatasetClaim: dataset.Claim{
-				Role:   dataset.Editor,
+				Role:   role.Editor,
 				NodeId: datasetID,
 				IntId:  1234,
 			}}

--- a/localtest.env
+++ b/localtest.env
@@ -10,3 +10,5 @@ DYNAMODB_URL=http://localhost:8000
 DELETE_RECORD_DYNAMODB_TABLE_NAME=TestDeleteRecords
 # s3 config
 MINIO_URL=http://localhost:9000
+# sqs config
+JOBS_QUEUE_ID=TestJobsQueueUrl

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -207,5 +207,19 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
     ]
   }
 
+  statement {
+    sid    = "PostChangeLogMessages"
+    effect = "Allow"
+
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_arn}/*",
+    ]
+  }
+
 }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "restore_package_lambda" {
   handler       = "restore_package"
   runtime       = "go1.x"
   role          = aws_iam_role.restore_package_lambda_role.arn
-  timeout       = 300
+  timeout       = 900
   memory_size   = 128
   s3_bucket     = var.lambda_bucket
   s3_key        = "${var.service_name}/restore-package-${var.image_tag}.zip"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -49,6 +49,7 @@ resource "aws_lambda_function" "restore_package_lambda" {
       RDS_PROXY_ENDPOINT                = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
       RESTORE_PACKAGE_QUEUE_URL         = aws_sqs_queue.restore_package_queue.url
       DELETE_RECORD_DYNAMODB_TABLE_NAME = data.terraform_remote_state.process_jobs_service.outputs.process_jobs_table_name
+      JOBS_QUEUE_ID                     = data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_id,
     }
   }
 }


### PR DESCRIPTION
PR sends package restore event messages to the SQS queue responsible for adding entries to the ChangeLog.

With this users should see a record of undeleted packages under a datasets Activity page.