### PR TITLE
refactor service to allow unauthenticated proxy

### DIFF
--- a/lambda/service/handler/root.go
+++ b/lambda/service/handler/root.go
@@ -12,7 +12,12 @@ func (h *RequestHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPRe
 	case "/restore":
 		restoreHandler := RestoreHandler{RequestHandler: *h}
 		return restoreHandler.handle(ctx)
-	case "/s3/proxy":
+	case "/presign/s3":
+		// Authenticated endpoint for generating presigned URLs
+		s3PresignHandler := S3PresignHandler{RequestHandler: *h}
+		return s3PresignHandler.handle(ctx)
+	case "/proxy/s3":
+		// Unauthenticated proxy endpoint that accepts presigned URLs
 		s3ProxyHandler := S3ProxyHandler{RequestHandler: *h}
 		return s3ProxyHandler.handle(ctx)
 	default:

--- a/lambda/service/handler/s3presign.go
+++ b/lambda/service/handler/s3presign.go
@@ -1,0 +1,383 @@
+package handler
+
+import (
+    "context"
+    "fmt"
+    "net/http"
+    "time"
+
+    "github.com/aws/aws-lambda-go/events"
+    "github.com/aws/aws-sdk-go-v2/aws"
+    v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+    log "github.com/sirupsen/logrus"
+)
+
+type S3PresignHandler struct {
+    RequestHandler
+}
+
+func (h *S3PresignHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
+    switch h.method {
+    case http.MethodGet:
+        return h.handleGet(ctx)
+    case http.MethodHead:
+        return h.handleHead(ctx)
+    case http.MethodOptions:
+        return h.handleOptions(ctx)
+    default:
+        return h.logAndBuildError(fmt.Sprintf("method %s not allowed", h.method), http.StatusMethodNotAllowed), nil
+    }
+}
+
+func (h *S3PresignHandler) handleOptions(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
+    h.logger.Info("handling OPTIONS request for S3 proxy")
+
+    headers := map[string]string{
+        "Access-Control-Allow-Origin":  "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Headers": "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Max-Age":       "3600",
+    }
+
+    return &events.APIGatewayV2HTTPResponse{
+        StatusCode: http.StatusNoContent,
+        Headers:    headers,
+    }, nil
+}
+
+func (h *S3PresignHandler) handleGet(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
+    // Get package ID from query parameters
+    packageId, ok := h.queryParams["package_id"]
+    if !ok || packageId == "" {
+        return h.logAndBuildError("missing required 'package_id' query parameter", http.StatusBadRequest), nil
+    }
+
+    datasetIdStr, ok := h.queryParams["dataset_id"]
+    if !ok || datasetIdStr == "" {
+        return h.logAndBuildError("missing required 'dataset_id' query parameter", http.StatusBadRequest), nil
+    }
+
+    // Check for optional path parameter for viewer assets
+    assetPath, isAssetRequest := h.queryParams["path"]
+
+    // Check for redirect preference (default to true for backwards compatibility)
+    redirectMode := true
+    if redirectParam, ok := h.queryParams["redirect"]; ok && redirectParam == "false" {
+        redirectMode = false
+    }
+
+    h.logger.WithFields(log.Fields{
+        "packageId":      packageId,
+        "datasetId":      datasetIdStr,
+        "assetPath":      assetPath,
+        "isAssetRequest": isAssetRequest,
+        "redirectMode":   redirectMode,
+    }).Info("handling GET request for package")
+
+    var s3Location *S3Location
+    var err error
+
+    if isAssetRequest && assetPath != "" {
+        // For viewer assets, validate package belongs to dataset and construct asset path
+        s3Location, err = h.getS3LocationForViewerAsset(ctx, packageId, datasetIdStr, assetPath)
+    } else {
+        // For package files, get S3 location from database and validate package belongs to dataset
+        s3Location, err = h.getS3LocationForPackage(ctx, packageId, datasetIdStr)
+    }
+    
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to get S3 location: %v", err), http.StatusInternalServerError), nil
+    }
+
+    // Generate presigned URL
+    presignedURL, err := h.generatePresignedURL(ctx, s3Location, http.MethodGet)
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to generate presigned URL: %v", err), http.StatusInternalServerError), nil
+    }
+
+    // Build response headers with CORS
+    headers := h.buildCORSHeaders()
+    
+    if redirectMode {
+        // Return redirect response (preferred for large files)
+        headers["Location"] = presignedURL
+
+        h.logger.WithFields(log.Fields{
+            "presignedURL": presignedURL,
+            "packageId":    packageId,
+            "datasetId":    datasetIdStr,
+        }).Debug("redirecting to presigned URL")
+
+        return &events.APIGatewayV2HTTPResponse{
+            StatusCode: http.StatusTemporaryRedirect,
+            Headers:    headers,
+            Body:       "",
+        }, nil
+    } else {
+        // Return presigned URL in response body (for clients that can't handle redirects)
+        // This mode is useful for DuckDB or other clients that might have issues with redirects
+        headers["Content-Type"] = "application/json"
+        
+        responseBody := fmt.Sprintf(`{"presigned_url": "%s"}`, presignedURL)
+        
+        h.logger.WithFields(log.Fields{
+            "presignedURL": presignedURL,
+            "packageId":    packageId,
+            "datasetId":    datasetIdStr,
+        }).Debug("returning presigned URL in response body")
+
+        return &events.APIGatewayV2HTTPResponse{
+            StatusCode: http.StatusOK,
+            Headers:    headers,
+            Body:       responseBody,
+        }, nil
+    }
+}
+
+func (h *S3PresignHandler) handleHead(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
+    // Get package ID from query parameters
+    packageId, ok := h.queryParams["package_id"]
+    if !ok || packageId == "" {
+        return h.logAndBuildError("missing required 'package_id' query parameter", http.StatusBadRequest), nil
+    }
+
+    datasetIdStr, ok := h.queryParams["dataset_id"]
+    if !ok || datasetIdStr == "" {
+        return h.logAndBuildError("missing required 'dataset_id' query parameter", http.StatusBadRequest), nil
+    }
+
+    // Check for optional path parameter for viewer assets
+    assetPath, isAssetRequest := h.queryParams["path"]
+
+    h.logger.WithFields(log.Fields{
+        "packageId":      packageId,
+        "datasetId":      datasetIdStr,
+        "assetPath":      assetPath,
+        "isAssetRequest": isAssetRequest,
+    }).Info("handling HEAD request for package metadata")
+
+    var s3Location *S3Location
+    var err error
+
+    if isAssetRequest && assetPath != "" {
+        // For viewer assets, validate package belongs to dataset and construct asset path
+        s3Location, err = h.getS3LocationForViewerAsset(ctx, packageId, datasetIdStr, assetPath)
+    } else {
+        // For package files, get S3 location from database and validate package belongs to dataset
+        s3Location, err = h.getS3LocationForPackage(ctx, packageId, datasetIdStr)
+    }
+    
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to get S3 location: %v", err), http.StatusInternalServerError), nil
+    }
+
+    // Generate presigned URL for HEAD request
+    presignedURL, err := h.generatePresignedURL(ctx, s3Location, http.MethodHead)
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to generate presigned URL: %v", err), http.StatusInternalServerError), nil
+    }
+
+    // Make HEAD request to S3 to get actual metadata
+    req, err := http.NewRequestWithContext(ctx, http.MethodHead, presignedURL, nil)
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to create HEAD request: %v", err), http.StatusInternalServerError), nil
+    }
+
+    client := &http.Client{
+        Timeout: 10 * time.Second,
+    }
+    resp, err := client.Do(req)
+    if err != nil {
+        return h.logAndBuildError(fmt.Sprintf("failed to fetch metadata from S3: %v", err), http.StatusBadGateway), nil
+    }
+    defer resp.Body.Close()
+
+    // Build response headers with CORS
+    headers := h.buildCORSHeaders()
+
+    // Forward relevant S3 response headers that DuckDB needs
+    h.forwardS3Headers(resp, headers)
+
+    h.logger.WithFields(log.Fields{
+        "contentLength": resp.Header.Get("Content-Length"),
+        "contentType":   resp.Header.Get("Content-Type"),
+        "packageId":     packageId,
+        "datasetId":     datasetIdStr,
+    }).Debug("returning HEAD response with S3 metadata")
+
+    return &events.APIGatewayV2HTTPResponse{
+        StatusCode: resp.StatusCode,
+        Headers:    headers,
+        Body:       "", // HEAD responses have no body
+    }, nil
+}
+
+// S3Location represents the S3 location of a package file
+type S3Location struct {
+    Bucket string
+    Key    string
+}
+
+// getS3LocationForPackage queries the database to get the S3 location for a package
+// and validates that the package belongs to the specified dataset
+func (h *S3PresignHandler) getS3LocationForPackage(ctx context.Context, packageNodeId, datasetNodeId string) (*S3Location, error) {
+    // Query that validates both package existence and dataset ownership
+    // This ensures users can only access packages from datasets they have permission for
+    query := fmt.Sprintf(`
+		SELECT f.s3_bucket, f.s3_key 
+		FROM "%d".files f 
+		JOIN "%d".packages p ON f.package_id = p.id 
+		JOIN "%d".datasets d ON p.dataset_id = d.id 
+		WHERE p.node_id = $1 AND d.node_id = $2
+		ORDER BY f.created_at DESC
+		LIMIT 1
+	`, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId)
+
+    var bucket, key string
+    err := PennsieveDB.QueryRowContext(ctx, query, packageNodeId, datasetNodeId).Scan(&bucket, &key)
+    if err != nil {
+        h.logger.WithError(err).WithFields(map[string]interface{}{
+            "packageNodeId": packageNodeId,
+            "datasetNodeId": datasetNodeId,
+        }).Error("failed to get S3 location from database or package does not belong to dataset")
+        return nil, fmt.Errorf("package not found, no associated file, or package does not belong to specified dataset: %w", err)
+    }
+
+    h.logger.WithFields(log.Fields{
+        "packageNodeId": packageNodeId,
+        "bucket":        bucket,
+        "key":           key,
+    }).Debug("retrieved S3 location for package")
+
+    return &S3Location{
+        Bucket: bucket,
+        Key:    key,
+    }, nil
+}
+
+// getS3LocationForViewerAsset validates that a package belongs to a dataset and constructs
+// the S3 location for viewer assets using the format: {ViewerAssetsBucket}/O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
+func (h *S3PresignHandler) getS3LocationForViewerAsset(ctx context.Context, packageNodeId, datasetNodeId, assetPath string) (*S3Location, error) {
+    // Validate that ViewerAssetsBucket is configured
+    if ViewerAssetsBucket == "" {
+        return nil, fmt.Errorf("viewer assets bucket not configured")
+    }
+
+    // Query to get the internal integer IDs and validate that the package belongs to the dataset
+    query := fmt.Sprintf(`
+        SELECT p.id, d.id
+        FROM "%d".packages p 
+        JOIN "%d".datasets d ON p.dataset_id = d.id 
+        WHERE p.node_id = $1 AND d.node_id = $2
+    `, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId)
+
+    var packageIntId, datasetIntId int64
+    err := PennsieveDB.QueryRowContext(ctx, query, packageNodeId, datasetNodeId).Scan(&packageIntId, &datasetIntId)
+    if err != nil {
+        h.logger.WithError(err).WithFields(map[string]interface{}{
+            "packageNodeId": packageNodeId,
+            "datasetNodeId": datasetNodeId,
+        }).Error("failed to get integer IDs for package and dataset or package does not belong to dataset")
+        return nil, fmt.Errorf("package not found or does not belong to specified dataset: %w", err)
+    }
+
+    // Construct the S3 key for the viewer asset using the new format
+    // Format: O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
+    assetKey := fmt.Sprintf("O%d/D%d/P%d/%s", h.claims.OrgClaim.IntId, datasetIntId, packageIntId, assetPath)
+
+    h.logger.WithFields(log.Fields{
+        "packageNodeId":      packageNodeId,
+        "datasetNodeId":      datasetNodeId,
+        "packageIntId":       packageIntId,
+        "datasetIntId":       datasetIntId,
+        "workspaceIntId":     h.claims.OrgClaim.IntId,
+        "assetPath":          assetPath,
+        "viewerAssetsBucket": ViewerAssetsBucket,
+        "assetKey":           assetKey,
+    }).Debug("constructed S3 location for viewer asset")
+
+    return &S3Location{
+        Bucket: ViewerAssetsBucket,
+        Key:    assetKey,
+    }, nil
+}
+
+// generatePresignedURL generates a presigned URL for the given S3 location
+func (h *S3PresignHandler) generatePresignedURL(ctx context.Context, location *S3Location, method string) (string, error) {
+    // Load AWS configuration
+    cfg, err := config.LoadDefaultConfig(ctx)
+    if err != nil {
+        return "", fmt.Errorf("failed to load AWS config: %w", err)
+    }
+
+    // Create S3 client
+    s3Client := s3.NewFromConfig(cfg)
+
+    // Create presigner
+    presigner := s3.NewPresignClient(s3Client)
+
+    // Generate presigned URL based on method
+    var presignedReq *v4.PresignedHTTPRequest
+
+    switch method {
+    case http.MethodGet:
+        presignedReq, err = presigner.PresignGetObject(ctx, &s3.GetObjectInput{
+            Bucket: aws.String(location.Bucket),
+            Key:    aws.String(location.Key),
+        }, func(opts *s3.PresignOptions) {
+            opts.Expires = time.Duration(3600 * time.Second) // 1 hour expiry
+        })
+    case http.MethodHead:
+        // For HEAD requests, we need to use GetObject presigner but the actual request will be HEAD
+        presignedReq, err = presigner.PresignGetObject(ctx, &s3.GetObjectInput{
+            Bucket: aws.String(location.Bucket),
+            Key:    aws.String(location.Key),
+        }, func(opts *s3.PresignOptions) {
+            opts.Expires = time.Duration(3600 * time.Second) // 1 hour expiry
+        })
+        // Note: The caller will need to use HEAD method with this URL
+    default:
+        return "", fmt.Errorf("unsupported method for presigned URL: %s", method)
+    }
+
+    if err != nil {
+        return "", fmt.Errorf("failed to generate presigned URL: %w", err)
+    }
+
+    return presignedReq.URL, nil
+}
+
+// buildCORSHeaders returns standard CORS headers
+func (h *S3PresignHandler) buildCORSHeaders() map[string]string {
+    return map[string]string{
+        "Access-Control-Allow-Origin":   "*",
+        "Access-Control-Allow-Methods":  "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Headers":  "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Expose-Headers": "Content-Length, Content-Type, Content-Range, ETag, Last-Modified, Accept-Ranges",
+    }
+}
+
+// forwardS3Headers forwards relevant headers from S3 response that DuckDB needs
+func (h *S3PresignHandler) forwardS3Headers(resp *http.Response, headers map[string]string) {
+    // Forward S3 response headers that are essential for DuckDB and other clients
+    headersToForward := []string{
+        "Content-Type",
+        "Content-Length", 
+        "Content-Range",
+        "ETag",
+        "Last-Modified",
+        "Accept-Ranges", // Critical for range requests
+        "Cache-Control",
+        "Content-Disposition",
+        "Content-Encoding",
+    }
+
+    for _, header := range headersToForward {
+        if value := resp.Header.Get(header); value != "" {
+            headers[header] = value
+        }
+    }
+}
+

--- a/lambda/service/handler/s3presign_test.go
+++ b/lambda/service/handler/s3presign_test.go
@@ -1,0 +1,665 @@
+package handler
+
+import (
+    "context"
+    "database/sql"
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "strings"
+    "testing"
+    "time"
+
+    "github.com/pennsieve/packages-service/api/store"
+    "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
+    "github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
+    "github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
+    "github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+    "github.com/pennsieve/pennsieve-go-core/pkg/models/role"
+    "github.com/pennsieve/pennsieve-go-core/pkg/models/user"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "github.com/stretchr/testify/suite"
+
+    // Import postgres driver
+    _ "github.com/lib/pq"
+)
+
+// S3PresignTestSuite contains tests for S3Presign handler using real database
+type S3PresignTestSuite struct {
+    suite.Suite
+    db     *sql.DB
+    orgId  int
+    claims *authorizer.Claims
+}
+
+func (suite *S3PresignTestSuite) SetupSuite() {
+    // Connect to test database using the same approach as working tests
+    pgConfig := &store.PostgresConfig{
+        Host:     getEnvOrDefault("POSTGRES_HOST", "localhost"),
+        Port:     getEnvOrDefault("POSTGRES_PORT", "5432"),
+        User:     getEnvOrDefault("POSTGRES_USER", "postgres"),
+        Password: getEnvOrDefault("POSTGRES_PASSWORD", "password"),
+        DBName:   getEnvOrDefault("PENNSIEVE_DB", "postgres"),
+        SSLMode:  getEnvOrDefault("POSTGRES_SSL_MODE", "disable"),
+    }
+
+    db, err := pgConfig.Open()
+    require.NoError(suite.T(), err)
+
+    // Retry database connection with backoff
+    err = suite.waitForDatabase(db)
+    if err != nil {
+        suite.T().Skipf("Database not available: %v", err)
+        return
+    }
+
+    suite.db = db
+    suite.orgId = 1 // Test organization
+
+    // Create test claims
+    suite.claims = &authorizer.Claims{
+        UserClaim: &user.Claim{
+            Id:           101,
+            NodeId:       "N:user:101",
+            IsSuperAdmin: false,
+        },
+        OrgClaim: &organization.Claim{
+            IntId:  int64(suite.orgId),
+            NodeId: "N:organization:1",
+            Role:   pgdb.Owner,
+        },
+        DatasetClaim: &dataset.Claim{
+            Role:   role.Editor,
+            NodeId: "N:dataset:1234",
+            IntId:  1234,
+        },
+    }
+
+    // Set up global database connection for handler
+    PennsieveDB = db
+}
+
+func (suite *S3PresignTestSuite) TearDownSuite() {
+    if suite.db != nil {
+        suite.db.Close()
+    }
+}
+
+func (suite *S3PresignTestSuite) SetupTest() {
+    // Clean up test data before each test
+    suite.cleanupTestData()
+}
+
+func (suite *S3PresignTestSuite) TearDownTest() {
+    // Clean up test data after each test
+    suite.cleanupTestData()
+}
+
+func (suite *S3PresignTestSuite) cleanupTestData() {
+    if suite.db == nil {
+        return
+    }
+
+    // Clean up files and packages tables - but preserve main test dataset N:dataset:1234
+    query := fmt.Sprintf(`DELETE FROM "%d".files WHERE s3_bucket LIKE 'test-%%'`, suite.orgId)
+    suite.db.Exec(query)
+
+    query = fmt.Sprintf(`DELETE FROM "%d".packages WHERE node_id LIKE 'N:package:test-%%'`, suite.orgId)
+    suite.db.Exec(query)
+
+    // Clean up only temporary test datasets (not the main N:dataset:1234)
+    query = fmt.Sprintf(`DELETE FROM "%d".datasets WHERE node_id LIKE 'N:dataset:test-%%'`, suite.orgId)
+    suite.db.Exec(query)
+}
+
+func (suite *S3PresignTestSuite) createTestPackageWithFile(nodeId, bucket, key string) int64 {
+    // First ensure we have a dataset - use INSERT ... ON CONFLICT with primary key
+    var datasetId int64
+    
+    // Try to get existing dataset first
+    err := suite.db.QueryRow(fmt.Sprintf(`
+		SELECT id FROM "%d".datasets WHERE node_id = $1
+	`, suite.orgId), "N:dataset:1234").Scan(&datasetId)
+    
+    if err != nil {
+        // Dataset doesn't exist, create it with a specific ID to avoid conflicts
+        err = suite.db.QueryRow(fmt.Sprintf(`
+			INSERT INTO "%d".datasets (id, node_id, name, state, status_id, created_at, updated_at)
+			VALUES (9999, $1, 'Test Dataset', 'READY'::text, 1, NOW(), NOW())
+			ON CONFLICT (id) DO UPDATE SET 
+				node_id = EXCLUDED.node_id,
+				updated_at = NOW()
+			RETURNING id
+		`, suite.orgId), "N:dataset:1234").Scan(&datasetId)
+        require.NoError(suite.T(), err)
+    }
+
+    // Insert test package with all required fields
+    packageQuery := fmt.Sprintf(`
+		INSERT INTO "%d".packages (name, type, state, node_id, dataset_id, owner_id, size, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+		RETURNING id
+	`, suite.orgId)
+
+    var packageId int64
+    err = suite.db.QueryRow(packageQuery, "test-package", "Package", "READY", nodeId, datasetId, 101, 1024).Scan(&packageId)
+    require.NoError(suite.T(), err)
+
+    // Insert test file with all required fields
+    fileQuery := fmt.Sprintf(`
+		INSERT INTO "%d".files (package_id, name, file_type, s3_bucket, s3_key, object_type, size, processing_state, uploaded_state, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+	`, suite.orgId)
+
+    _, err = suite.db.Exec(fileQuery, packageId, "test-file.txt", 1, bucket, key, "source", 1024, "processed", "Uploaded")
+    require.NoError(suite.T(), err)
+
+    return packageId
+}
+
+func (suite *S3PresignTestSuite) TestHandleOptions() {
+    req := newTestRequest("OPTIONS", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": "N:package:test-123",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handleOptions(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusNoContent, resp.StatusCode)
+    assert.Equal(suite.T(), "*", resp.Headers["Access-Control-Allow-Origin"])
+    assert.Equal(suite.T(), "GET, HEAD, OPTIONS", resp.Headers["Access-Control-Allow-Methods"])
+    assert.Equal(suite.T(), "Authorization, Content-Type, Range, Origin, Accept", resp.Headers["Access-Control-Allow-Headers"])
+    assert.Equal(suite.T(), "3600", resp.Headers["Access-Control-Max-Age"])
+}
+
+func (suite *S3PresignTestSuite) TestHandleGetMissingPackageId() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handleGet(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "missing required 'package_id' query parameter")
+}
+
+func (suite *S3PresignTestSuite) TestHandleGetMissingDatasetId() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "package_id": "N:package:test-123",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handleGet(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "missing required 'dataset_id' query parameter")
+}
+
+func (suite *S3PresignTestSuite) TestHandleGetPackageNotFound() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": "N:package:nonexistent",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handleGet(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusInternalServerError, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "failed to get S3 location")
+}
+
+func (suite *S3PresignTestSuite) TestHandleGetWithMockS3() {
+    // Create test package and file
+    packageNodeId := "N:package:test-123"
+    testBucket := "test-bucket"
+    testKey := "test-key"
+
+    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
+
+    // Create mock S3 server
+    testContent := "Hello, World!"
+    mockS3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Verify the request contains our test bucket and key in the path
+        if r.URL.Path == "/test-bucket/test-key" || r.URL.Path == fmt.Sprintf("/%s/%s", testBucket, testKey) {
+            w.Header().Set("Content-Type", "text/plain")
+            w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testContent)))
+            w.Header().Set("ETag", `"test-etag"`)
+            w.WriteHeader(http.StatusOK)
+            w.Write([]byte(testContent))
+        } else {
+            w.WriteHeader(http.StatusNotFound)
+        }
+    }))
+    defer mockS3Server.Close()
+
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": packageNodeId,
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    // Mock the generatePresignedURL method to return our test server URL
+    originalHandler := handler
+
+    // For this test, we'll test just the database query part
+    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
+    assert.Equal(suite.T(), testKey, s3Location.Key)
+
+    // Test CORS headers method
+    corsHeaders := originalHandler.buildCORSHeaders()
+    assert.Equal(suite.T(), "*", corsHeaders["Access-Control-Allow-Origin"])
+    assert.Equal(suite.T(), "GET, HEAD, OPTIONS", corsHeaders["Access-Control-Allow-Methods"])
+}
+
+func (suite *S3PresignTestSuite) TestHandleHeadMissingPackageId() {
+    req := newTestRequest("HEAD", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handleHead(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "missing required 'package_id' query parameter")
+}
+
+func (suite *S3PresignTestSuite) TestGetS3LocationForPackage() {
+    // Create test package and file
+    packageNodeId := "N:package:test-456"
+    testBucket := "test-bucket-2"
+    testKey := "test-key-2"
+
+    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
+
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{}, "")
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
+    assert.Equal(suite.T(), testKey, s3Location.Key)
+}
+
+func (suite *S3PresignTestSuite) TestGetS3LocationForNonexistentPackage() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{}, "")
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    _, err := handler.getS3LocationForPackage(context.Background(), "N:package:nonexistent", "N:dataset:1234")
+
+    assert.Error(suite.T(), err)
+    assert.Contains(suite.T(), err.Error(), "package not found")
+}
+
+func (suite *S3PresignTestSuite) TestBuildCORSHeaders() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{}, "")
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    headers := handler.buildCORSHeaders()
+
+    expectedHeaders := map[string]string{
+        "Access-Control-Allow-Origin":   "*",
+        "Access-Control-Allow-Methods":  "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Headers":  "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Expose-Headers": "Content-Length, Content-Type, Content-Range, ETag, Last-Modified, Accept-Ranges",
+    }
+
+    for key, expectedValue := range expectedHeaders {
+        assert.Equal(suite.T(), expectedValue, headers[key], "Header %s should match", key)
+    }
+}
+
+func (suite *S3PresignTestSuite) TestForwardS3Headers() {
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{}, "")
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    // Create a mock HTTP response
+    resp := &http.Response{
+        Header: make(http.Header),
+    }
+    resp.Header.Set("Content-Type", "text/plain")
+    resp.Header.Set("Content-Length", "123")
+    resp.Header.Set("ETag", `"test-etag"`)
+    resp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+    resp.Header.Set("Accept-Ranges", "bytes")
+    resp.Header.Set("X-Custom-Header", "should-not-be-forwarded") // This should not be forwarded
+
+    headers := make(map[string]string)
+    handler.forwardS3Headers(resp, headers)
+
+    // Check that expected headers are forwarded
+    assert.Equal(suite.T(), "text/plain", headers["Content-Type"])
+    assert.Equal(suite.T(), "123", headers["Content-Length"])
+    assert.Equal(suite.T(), `"test-etag"`, headers["ETag"])
+    assert.Equal(suite.T(), "Wed, 21 Oct 2015 07:28:00 GMT", headers["Last-Modified"])
+    assert.Equal(suite.T(), "bytes", headers["Accept-Ranges"])
+
+    // Check that custom headers are not forwarded
+    _, exists := headers["X-Custom-Header"]
+    assert.False(suite.T(), exists, "Custom headers should not be forwarded")
+}
+
+func (suite *S3PresignTestSuite) TestHandleMethodNotAllowed() {
+    req := newTestRequest("PUT", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": "N:package:test-123",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    resp, err := handler.handle(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusMethodNotAllowed, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "method PUT not allowed")
+}
+
+func (suite *S3PresignTestSuite) TestViewerAssetAccess() {
+    if suite.db == nil {
+        suite.T().Skip("Database not available for viewer asset test")
+        return
+    }
+
+    // Set up ViewerAssetsBucket for testing
+    originalBucket := ViewerAssetsBucket
+    ViewerAssetsBucket = "test-viewer-assets-bucket"
+    defer func() { ViewerAssetsBucket = originalBucket }()
+
+    // Create test package and dataset
+    packageNodeId := "N:package:test-asset-pkg"
+    datasetNodeId := "N:dataset:1234"
+
+    suite.createTestPackageWithFile(packageNodeId, "original-bucket", "original-key")
+
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": datasetNodeId,
+        "package_id": packageNodeId,
+        "path":       "preview/thumbnail.jpg",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    // Test the getS3LocationForViewerAsset function directly
+    s3Location, err := handler.getS3LocationForViewerAsset(context.Background(), packageNodeId, datasetNodeId, "preview/thumbnail.jpg")
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), "test-viewer-assets-bucket", s3Location.Bucket)
+
+    // Expected format: O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
+    // Get the actual dataset internal ID from the database
+    var actualDatasetIntId int64
+    err = suite.db.QueryRow(fmt.Sprintf(`SELECT id FROM "%d".datasets WHERE node_id = $1`, suite.orgId), datasetNodeId).Scan(&actualDatasetIntId)
+    require.NoError(suite.T(), err)
+
+    expectedKeyPrefix := fmt.Sprintf("O%d/D%d/P", suite.orgId, actualDatasetIntId)
+    assert.True(suite.T(), strings.HasPrefix(s3Location.Key, expectedKeyPrefix), "Key should start with %s, but got: %s", expectedKeyPrefix, s3Location.Key)
+    assert.True(suite.T(), strings.HasSuffix(s3Location.Key, "/preview/thumbnail.jpg"), "Key should end with asset path")
+}
+
+func (suite *S3PresignTestSuite) TestViewerAssetAccessUnauthorized() {
+    if suite.db == nil {
+        suite.T().Skip("Database not available for viewer asset unauthorized test")
+        return
+    }
+
+    // Set up ViewerAssetsBucket for testing
+    originalBucket := ViewerAssetsBucket
+    ViewerAssetsBucket = "test-viewer-assets-bucket"
+    defer func() { ViewerAssetsBucket = originalBucket }()
+
+    // Try to access viewer asset for non-existent package
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": "N:package:nonexistent",
+        "path":       "preview/thumbnail.jpg",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    _, err := handler.getS3LocationForViewerAsset(context.Background(), "N:package:nonexistent", "N:dataset:1234", "preview/thumbnail.jpg")
+
+    assert.Error(suite.T(), err)
+    assert.Contains(suite.T(), err.Error(), "package not found or does not belong to specified dataset")
+}
+
+func (suite *S3PresignTestSuite) TestViewerAssetBucketNotConfigured() {
+    // Set ViewerAssetsBucket to empty to test error handling
+    originalBucket := ViewerAssetsBucket
+    ViewerAssetsBucket = ""
+    defer func() { ViewerAssetsBucket = originalBucket }()
+
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": "N:package:test",
+        "path":       "preview/thumbnail.jpg",
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    _, err := handler.getS3LocationForViewerAsset(context.Background(), "N:package:test", "N:dataset:1234", "preview/thumbnail.jpg")
+
+    assert.Error(suite.T(), err)
+    assert.Contains(suite.T(), err.Error(), "viewer assets bucket not configured")
+}
+
+func (suite *S3PresignTestSuite) TestHandleGetWithPathParameter() {
+    // Create test package and file
+    packageNodeId := "N:package:test-with-path"
+    testBucket := "test-bucket"
+    testKey := "test-key"
+
+    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
+
+    // Test GET request without path (should use original package file logic)
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": "N:dataset:1234",
+        "package_id": packageNodeId,
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, suite.claims)}
+
+    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
+    assert.Equal(suite.T(), testKey, s3Location.Key)
+}
+
+func (suite *S3PresignTestSuite) TestCrossDatasetAccessDenied() {
+    if suite.db == nil {
+        suite.T().Skip("Database not available for cross-dataset access test")
+        return
+    }
+
+    // Use org ID from suite setup
+    orgId := int64(suite.orgId)
+
+    // Create unique node IDs to avoid conflicts with current timestamp + random component
+    timestamp := fmt.Sprintf("%d-%d", time.Now().UnixNano(), time.Now().Unix())
+    dataset1NodeId := fmt.Sprintf("N:dataset:test-unauthorized-%s", timestamp)
+    dataset2NodeId := fmt.Sprintf("N:dataset:test-authorized-%s", timestamp)
+    packageNodeId := fmt.Sprintf("N:package:test-unauthorized-pkg-%s", timestamp)
+
+    // More thorough cleanup before test to avoid any ID conflicts
+    suite.cleanupTestData()
+    
+    // Delete everything in reverse dependency order to avoid foreign key violations
+    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".files WHERE s3_bucket LIKE 'test-%%' OR s3_bucket = 'test-unauthorized-bucket'`, orgId))
+    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".packages WHERE node_id LIKE 'N:package:test-%%'`, orgId))
+    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".datasets WHERE node_id LIKE 'N:dataset:test-%%' OR id = 9999 OR node_id LIKE '%%test-unauthorized%%' OR node_id LIKE '%%test-authorized%%'`, orgId))
+    
+    // Reset the auto-increment sequence to avoid conflicts
+    var maxId int
+    suite.db.QueryRow(fmt.Sprintf(`SELECT COALESCE(MAX(id), 0) FROM "%d".datasets`, orgId)).Scan(&maxId)
+    suite.db.Exec(fmt.Sprintf(`SELECT setval('"%d".datasets_id_seq', %d)`, orgId, maxId+1))
+
+    // Insert datasets using simple INSERT since we cleaned up beforehand
+    var dataset1Id, dataset2Id int64
+
+    err := suite.db.QueryRow(fmt.Sprintf(`
+		INSERT INTO "%d".datasets (node_id, name, state, status_id, created_at, updated_at)
+		VALUES ($1, 'Test Unauthorized Dataset', 'READY'::text, 1, NOW(), NOW())
+		RETURNING id
+	`, orgId), dataset1NodeId).Scan(&dataset1Id)
+    require.NoError(suite.T(), err)
+
+    err = suite.db.QueryRow(fmt.Sprintf(`
+		INSERT INTO "%d".datasets (node_id, name, state, status_id, created_at, updated_at)
+		VALUES ($1, 'Test Authorized Dataset', 'READY'::text, 1, NOW(), NOW())
+		RETURNING id
+	`, orgId), dataset2NodeId).Scan(&dataset2Id)
+    require.NoError(suite.T(), err)
+
+    // Create a package in dataset1 (unauthorized) without specifying ID
+    var packageId int64
+    err = suite.db.QueryRow(fmt.Sprintf(`
+		INSERT INTO "%d".packages (node_id, name, type, state, dataset_id, owner_id, size, created_at, updated_at)
+		VALUES ($1, 'Test Unauthorized Package', 'Package', 'READY', $2, 101, 1024, NOW(), NOW())
+		RETURNING id
+	`, orgId), packageNodeId, dataset1Id).Scan(&packageId)
+    require.NoError(suite.T(), err)
+
+    // Create a file for the package - use minimal required fields to avoid column type issues
+    _, err = suite.db.Exec(fmt.Sprintf(`
+		INSERT INTO "%d".files (package_id, name, file_type, s3_bucket, s3_key, object_type, processing_state, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+	`, orgId), packageId, "test-unauthorized-file.txt", 1, "test-unauthorized-bucket", "test/unauthorized-file.txt", "source", "processed")
+    require.NoError(suite.T(), err)
+
+    // Create claims for user with access only to dataset2, NOT dataset1
+    unauthorizedClaims := &authorizer.Claims{
+        UserClaim: &user.Claim{
+            Id:           101,
+            NodeId:       "N:user:101",
+            IsSuperAdmin: false,
+        },
+        OrgClaim: &organization.Claim{
+            IntId:  orgId,
+            NodeId: "N:organization:1",
+            Role:   pgdb.Owner,
+        },
+        DatasetClaim: &dataset.Claim{
+            Role:   role.Editor,
+            NodeId: dataset2NodeId, // User only has access to dataset2
+            IntId:  dataset2Id,
+        },
+    }
+
+    // Attempt to access package from dataset1 using credentials for dataset2
+    req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{
+        "dataset_id": dataset2NodeId, // Authorized dataset
+        "package_id": packageNodeId,  // Package from unauthorized dataset1
+    }, "")
+
+    handler := S3PresignHandler{RequestHandler: *NewHandler(req, unauthorizedClaims)}
+
+    resp, err := handler.handle(context.Background())
+
+    require.NoError(suite.T(), err)
+    assert.Equal(suite.T(), http.StatusInternalServerError, resp.StatusCode)
+    assert.Contains(suite.T(), resp.Body, "package not found, no associated file, or package does not belong to specified dataset")
+}
+
+// waitForDatabase waits for the database to be available with exponential backoff
+func (suite *S3PresignTestSuite) waitForDatabase(db *sql.DB) error {
+    maxRetries := 10
+    backoff := time.Millisecond * 100
+
+    for i := 0; i < maxRetries; i++ {
+        err := db.Ping()
+        if err == nil {
+            return nil
+        }
+
+        suite.T().Logf("Database connection attempt %d failed: %v. Retrying in %v...", i+1, err, backoff)
+        time.Sleep(backoff)
+        backoff *= 2 // Exponential backoff
+
+        if backoff > time.Second*5 {
+            backoff = time.Second * 5 // Cap at 5 seconds
+        }
+    }
+
+    // Final attempt
+    return db.Ping()
+}
+
+// Helper function to get environment variable with default
+func getEnvOrDefault(key, defaultValue string) string {
+    if value := os.Getenv(key); value != "" {
+        return value
+    }
+    return defaultValue
+}
+
+// TestS3PresignTestSuite runs the test suite
+func TestS3PresignTestSuite(t *testing.T) {
+    if testing.Short() {
+        t.Skip("Skipping database integration tests in short mode")
+    }
+    suite.Run(t, new(S3PresignTestSuite))
+}
+
+// Individual unit tests that don't require database
+
+func TestS3PresignHandleUnitTests(t *testing.T) {
+    // Test individual methods without database dependency
+    claims := &authorizer.Claims{
+        UserClaim: &user.Claim{
+            Id:           101,
+            NodeId:       "N:user:101",
+            IsSuperAdmin: false,
+        },
+        OrgClaim: &organization.Claim{
+            IntId:  1,
+            NodeId: "N:organization:1",
+            Role:   pgdb.Owner,
+        },
+        DatasetClaim: &dataset.Claim{
+            Role:   role.Editor,
+            NodeId: "N:dataset:1234",
+            IntId:  1234,
+        },
+    }
+
+    t.Run("handleOptions", func(t *testing.T) {
+        req := newTestRequest("OPTIONS", "/presign/s3", "test-request-id", map[string]string{
+            "dataset_id": "N:dataset:1234",
+        }, "")
+
+        handler := S3PresignHandler{RequestHandler: *NewHandler(req, claims)}
+
+        resp, err := handler.handleOptions(context.Background())
+
+        require.NoError(t, err)
+        assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+        assert.Equal(t, "*", resp.Headers["Access-Control-Allow-Origin"])
+    })
+
+    t.Run("buildCORSHeaders", func(t *testing.T) {
+        req := newTestRequest("GET", "/presign/s3", "test-request-id", map[string]string{}, "")
+        handler := S3PresignHandler{RequestHandler: *NewHandler(req, claims)}
+
+        headers := handler.buildCORSHeaders()
+        assert.Equal(t, "*", headers["Access-Control-Allow-Origin"])
+        assert.Equal(t, "GET, HEAD, OPTIONS", headers["Access-Control-Allow-Methods"])
+    })
+}

--- a/lambda/service/handler/s3proxy.go
+++ b/lambda/service/handler/s3proxy.go
@@ -4,13 +4,11 @@ import (
     "context"
     "fmt"
     "net/http"
+    "net/url"
+    "strings"
     "time"
 
     "github.com/aws/aws-lambda-go/events"
-    "github.com/aws/aws-sdk-go-v2/aws"
-    v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-    "github.com/aws/aws-sdk-go-v2/config"
-    "github.com/aws/aws-sdk-go-v2/service/s3"
     log "github.com/sirupsen/logrus"
 )
 
@@ -32,12 +30,12 @@ func (h *S3ProxyHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPRe
 }
 
 func (h *S3ProxyHandler) handleOptions(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
-    h.logger.Info("handling OPTIONS request for S3 proxy")
+    h.logger.Info("handling OPTIONS request for S3 proxy (unauthenticated)")
 
     headers := map[string]string{
         "Access-Control-Allow-Origin":  "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-        "Access-Control-Allow-Headers": "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Allow-Headers": "Content-Type, Range, Origin, Accept",
         "Access-Control-Max-Age":       "3600",
     }
 
@@ -48,136 +46,47 @@ func (h *S3ProxyHandler) handleOptions(ctx context.Context) (*events.APIGatewayV
 }
 
 func (h *S3ProxyHandler) handleGet(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
-    // Get package ID from query parameters
-    packageId, ok := h.queryParams["package_id"]
-    if !ok || packageId == "" {
-        return h.logAndBuildError("missing required 'package_id' query parameter", http.StatusBadRequest), nil
+    // Get presigned URL from query parameters
+    presignedURL, ok := h.queryParams["presigned_url"]
+    if !ok || presignedURL == "" {
+        return h.logAndBuildError("missing required 'presigned_url' query parameter", http.StatusBadRequest), nil
     }
 
-    datasetIdStr, ok := h.queryParams["dataset_id"]
-    if !ok || datasetIdStr == "" {
-        return h.logAndBuildError("missing required 'dataset_id' query parameter", http.StatusBadRequest), nil
-    }
-
-    // Check for optional path parameter for viewer assets
-    assetPath, isAssetRequest := h.queryParams["path"]
-
-    // Check for redirect preference (default to true for backwards compatibility)
-    redirectMode := true
-    if redirectParam, ok := h.queryParams["redirect"]; ok && redirectParam == "false" {
-        redirectMode = false
+    // Validate the presigned URL
+    if err := h.validatePresignedURL(presignedURL); err != nil {
+        return h.logAndBuildError(fmt.Sprintf("invalid presigned URL: %v", err), http.StatusBadRequest), nil
     }
 
     h.logger.WithFields(log.Fields{
-        "packageId":      packageId,
-        "datasetId":      datasetIdStr,
-        "assetPath":      assetPath,
-        "isAssetRequest": isAssetRequest,
-        "redirectMode":   redirectMode,
-    }).Info("handling GET request for package")
-
-    var s3Location *S3Location
-    var err error
-
-    if isAssetRequest && assetPath != "" {
-        // For viewer assets, validate package belongs to dataset and construct asset path
-        s3Location, err = h.getS3LocationForViewerAsset(ctx, packageId, datasetIdStr, assetPath)
-    } else {
-        // For package files, get S3 location from database and validate package belongs to dataset
-        s3Location, err = h.getS3LocationForPackage(ctx, packageId, datasetIdStr)
-    }
-    
-    if err != nil {
-        return h.logAndBuildError(fmt.Sprintf("failed to get S3 location: %v", err), http.StatusInternalServerError), nil
-    }
-
-    // Generate presigned URL
-    presignedURL, err := h.generatePresignedURL(ctx, s3Location, http.MethodGet)
-    if err != nil {
-        return h.logAndBuildError(fmt.Sprintf("failed to generate presigned URL: %v", err), http.StatusInternalServerError), nil
-    }
+        "presignedURL": presignedURL,
+    }).Info("redirecting to presigned URL")
 
     // Build response headers with CORS
     headers := h.buildCORSHeaders()
-    
-    if redirectMode {
-        // Return redirect response (preferred for large files)
-        headers["Location"] = presignedURL
+    headers["Location"] = presignedURL
 
-        h.logger.WithFields(log.Fields{
-            "presignedURL": presignedURL,
-            "packageId":    packageId,
-            "datasetId":    datasetIdStr,
-        }).Debug("redirecting to presigned URL")
-
-        return &events.APIGatewayV2HTTPResponse{
-            StatusCode: http.StatusTemporaryRedirect,
-            Headers:    headers,
-            Body:       "",
-        }, nil
-    } else {
-        // Return presigned URL in response body (for clients that can't handle redirects)
-        // This mode is useful for DuckDB or other clients that might have issues with redirects
-        headers["Content-Type"] = "application/json"
-        
-        responseBody := fmt.Sprintf(`{"presigned_url": "%s"}`, presignedURL)
-        
-        h.logger.WithFields(log.Fields{
-            "presignedURL": presignedURL,
-            "packageId":    packageId,
-            "datasetId":    datasetIdStr,
-        }).Debug("returning presigned URL in response body")
-
-        return &events.APIGatewayV2HTTPResponse{
-            StatusCode: http.StatusOK,
-            Headers:    headers,
-            Body:       responseBody,
-        }, nil
-    }
+    return &events.APIGatewayV2HTTPResponse{
+        StatusCode: http.StatusTemporaryRedirect,
+        Headers:    headers,
+        Body:       "",
+    }, nil
 }
 
 func (h *S3ProxyHandler) handleHead(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
-    // Get package ID from query parameters
-    packageId, ok := h.queryParams["package_id"]
-    if !ok || packageId == "" {
-        return h.logAndBuildError("missing required 'package_id' query parameter", http.StatusBadRequest), nil
+    // Get presigned URL from query parameters
+    presignedURL, ok := h.queryParams["presigned_url"]
+    if !ok || presignedURL == "" {
+        return h.logAndBuildError("missing required 'presigned_url' query parameter", http.StatusBadRequest), nil
     }
 
-    datasetIdStr, ok := h.queryParams["dataset_id"]
-    if !ok || datasetIdStr == "" {
-        return h.logAndBuildError("missing required 'dataset_id' query parameter", http.StatusBadRequest), nil
+    // Validate the presigned URL
+    if err := h.validatePresignedURL(presignedURL); err != nil {
+        return h.logAndBuildError(fmt.Sprintf("invalid presigned URL: %v", err), http.StatusBadRequest), nil
     }
-
-    // Check for optional path parameter for viewer assets
-    assetPath, isAssetRequest := h.queryParams["path"]
 
     h.logger.WithFields(log.Fields{
-        "packageId":      packageId,
-        "datasetId":      datasetIdStr,
-        "assetPath":      assetPath,
-        "isAssetRequest": isAssetRequest,
-    }).Info("handling HEAD request for package metadata")
-
-    var s3Location *S3Location
-    var err error
-
-    if isAssetRequest && assetPath != "" {
-        // For viewer assets, validate package belongs to dataset and construct asset path
-        s3Location, err = h.getS3LocationForViewerAsset(ctx, packageId, datasetIdStr, assetPath)
-    } else {
-        // For package files, get S3 location from database and validate package belongs to dataset
-        s3Location, err = h.getS3LocationForPackage(ctx, packageId, datasetIdStr)
-    }
-    
-    if err != nil {
-        return h.logAndBuildError(fmt.Sprintf("failed to get S3 location: %v", err), http.StatusInternalServerError), nil
-    }
-
-    // Generate presigned URL for HEAD request
-    presignedURL, err := h.generatePresignedURL(ctx, s3Location, http.MethodHead)
-    if err != nil {
-        return h.logAndBuildError(fmt.Sprintf("failed to generate presigned URL: %v", err), http.StatusInternalServerError), nil
-    }
+        "presignedURL": presignedURL,
+    }).Info("handling HEAD request for S3 metadata")
 
     // Make HEAD request to S3 to get actual metadata
     req, err := http.NewRequestWithContext(ctx, http.MethodHead, presignedURL, nil)
@@ -197,14 +106,12 @@ func (h *S3ProxyHandler) handleHead(ctx context.Context) (*events.APIGatewayV2HT
     // Build response headers with CORS
     headers := h.buildCORSHeaders()
 
-    // Forward relevant S3 response headers that DuckDB needs
+    // Forward relevant S3 response headers
     h.forwardS3Headers(resp, headers)
 
     h.logger.WithFields(log.Fields{
         "contentLength": resp.Header.Get("Content-Length"),
         "contentType":   resp.Header.Get("Content-Type"),
-        "packageId":     packageId,
-        "datasetId":     datasetIdStr,
     }).Debug("returning HEAD response with S3 metadata")
 
     return &events.APIGatewayV2HTTPResponse{
@@ -214,139 +121,141 @@ func (h *S3ProxyHandler) handleHead(ctx context.Context) (*events.APIGatewayV2HT
     }, nil
 }
 
-// S3Location represents the S3 location of a package file
-type S3Location struct {
-    Bucket string
-    Key    string
+// validatePresignedURL validates that the URL is a valid S3 presigned URL
+func (h *S3ProxyHandler) validatePresignedURL(presignedURL string) error {
+    parsedURL, err := url.Parse(presignedURL)
+    if err != nil {
+        return fmt.Errorf("failed to parse URL: %w", err)
+    }
+
+    // Check that it's an HTTPS URL
+    if parsedURL.Scheme != "https" {
+        return fmt.Errorf("URL must use HTTPS scheme")
+    }
+
+    // Check that it's an S3 URL (amazonaws.com domain)
+    if parsedURL.Host == "" {
+        return fmt.Errorf("URL must have a valid host")
+    }
+
+    // Basic validation that it looks like an S3 URL
+    // This could be made more strict if needed
+    // Examples of valid S3 hosts:
+    // - bucket-name.s3.amazonaws.com
+    // - bucket-name.s3.region.amazonaws.com
+    // - s3.amazonaws.com/bucket-name
+    // - s3.region.amazonaws.com/bucket-name
+    if !isS3URL(parsedURL.Host) {
+        return fmt.Errorf("URL must be an S3 URL")
+    }
+
+    // Extract bucket name from the URL
+    bucketName := extractBucketName(parsedURL)
+    if bucketName == "" {
+        return fmt.Errorf("could not determine bucket name from URL")
+    }
+
+    // Validate against allowed buckets if configured
+    if len(ProxyAllowedBuckets) > 0 {
+        allowed := false
+        for _, allowedBucket := range ProxyAllowedBuckets {
+            if bucketName == allowedBucket {
+                allowed = true
+                break
+            }
+        }
+        if !allowed {
+            h.logger.WithFields(log.Fields{
+                "bucket": bucketName,
+                "allowed_buckets": ProxyAllowedBuckets,
+            }).Warn("attempted access to non-allowed bucket")
+            return fmt.Errorf("bucket %s is not in the allowed list", bucketName)
+        }
+    }
+
+    // Check for required presigned URL query parameters
+    queryParams := parsedURL.Query()
+    
+    // Check for AWS Signature Version 4 parameters
+    if queryParams.Get("X-Amz-Algorithm") == "" &&
+       queryParams.Get("X-Amz-Credential") == "" &&
+       queryParams.Get("X-Amz-Signature") == "" {
+        // Check for AWS Signature Version 2 parameters (legacy)
+        if queryParams.Get("AWSAccessKeyId") == "" &&
+           queryParams.Get("Signature") == "" {
+            return fmt.Errorf("URL does not appear to be a valid presigned URL (missing signature parameters)")
+        }
+    }
+
+    return nil
 }
 
-// getS3LocationForPackage queries the database to get the S3 location for a package
-// and validates that the package belongs to the specified dataset
-func (h *S3ProxyHandler) getS3LocationForPackage(ctx context.Context, packageNodeId, datasetNodeId string) (*S3Location, error) {
-    // Query that validates both package existence and dataset ownership
-    // This ensures users can only access packages from datasets they have permission for
-    query := fmt.Sprintf(`
-		SELECT f.s3_bucket, f.s3_key 
-		FROM "%d".files f 
-		JOIN "%d".packages p ON f.package_id = p.id 
-		JOIN "%d".datasets d ON p.dataset_id = d.id 
-		WHERE p.node_id = $1 AND d.node_id = $2
-		ORDER BY f.created_at DESC
-		LIMIT 1
-	`, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId)
-
-    var bucket, key string
-    err := PennsieveDB.QueryRowContext(ctx, query, packageNodeId, datasetNodeId).Scan(&bucket, &key)
-    if err != nil {
-        h.logger.WithError(err).WithFields(map[string]interface{}{
-            "packageNodeId": packageNodeId,
-            "datasetNodeId": datasetNodeId,
-        }).Error("failed to get S3 location from database or package does not belong to dataset")
-        return nil, fmt.Errorf("package not found, no associated file, or package does not belong to specified dataset: %w", err)
+// extractBucketName extracts the bucket name from an S3 URL
+func extractBucketName(parsedURL *url.URL) string {
+    host := parsedURL.Host
+    path := parsedURL.Path
+    
+    // Virtual-hosted-style URLs: bucket-name.s3.amazonaws.com
+    // or bucket-name.s3.region.amazonaws.com
+    if contains(host, ".s3.") || contains(host, ".s3-") {
+        // The bucket name is the first part of the host
+        parts := strings.Split(host, ".")
+        if len(parts) > 0 {
+            return parts[0]
+        }
     }
-
-    h.logger.WithFields(log.Fields{
-        "packageNodeId": packageNodeId,
-        "bucket":        bucket,
-        "key":           key,
-    }).Debug("retrieved S3 location for package")
-
-    return &S3Location{
-        Bucket: bucket,
-        Key:    key,
-    }, nil
+    
+    // Path-style URLs: s3.amazonaws.com/bucket-name/key
+    // or s3.region.amazonaws.com/bucket-name/key
+    if strings.HasPrefix(host, "s3.") || strings.HasPrefix(host, "s3-") {
+        // The bucket name is the first part of the path
+        if path != "" && path != "/" {
+            // Remove leading slash
+            if strings.HasPrefix(path, "/") {
+                path = path[1:]
+            }
+            // Get the first path segment
+            parts := strings.Split(path, "/")
+            if len(parts) > 0 && parts[0] != "" {
+                return parts[0]
+            }
+        }
+    }
+    
+    return ""
 }
 
-// getS3LocationForViewerAsset validates that a package belongs to a dataset and constructs
-// the S3 location for viewer assets using the format: {ViewerAssetsBucket}/O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
-func (h *S3ProxyHandler) getS3LocationForViewerAsset(ctx context.Context, packageNodeId, datasetNodeId, assetPath string) (*S3Location, error) {
-    // Validate that ViewerAssetsBucket is configured
-    if ViewerAssetsBucket == "" {
-        return nil, fmt.Errorf("viewer assets bucket not configured")
-    }
-
-    // Query to get the internal integer IDs and validate that the package belongs to the dataset
-    query := fmt.Sprintf(`
-        SELECT p.id, d.id
-        FROM "%d".packages p 
-        JOIN "%d".datasets d ON p.dataset_id = d.id 
-        WHERE p.node_id = $1 AND d.node_id = $2
-    `, h.claims.OrgClaim.IntId, h.claims.OrgClaim.IntId)
-
-    var packageIntId, datasetIntId int64
-    err := PennsieveDB.QueryRowContext(ctx, query, packageNodeId, datasetNodeId).Scan(&packageIntId, &datasetIntId)
-    if err != nil {
-        h.logger.WithError(err).WithFields(map[string]interface{}{
-            "packageNodeId": packageNodeId,
-            "datasetNodeId": datasetNodeId,
-        }).Error("failed to get integer IDs for package and dataset or package does not belong to dataset")
-        return nil, fmt.Errorf("package not found or does not belong to specified dataset: %w", err)
-    }
-
-    // Construct the S3 key for the viewer asset using the new format
-    // Format: O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
-    assetKey := fmt.Sprintf("O%d/D%d/P%d/%s", h.claims.OrgClaim.IntId, datasetIntId, packageIntId, assetPath)
-
-    h.logger.WithFields(log.Fields{
-        "packageNodeId":      packageNodeId,
-        "datasetNodeId":      datasetNodeId,
-        "packageIntId":       packageIntId,
-        "datasetIntId":       datasetIntId,
-        "workspaceIntId":     h.claims.OrgClaim.IntId,
-        "assetPath":          assetPath,
-        "viewerAssetsBucket": ViewerAssetsBucket,
-        "assetKey":           assetKey,
-    }).Debug("constructed S3 location for viewer asset")
-
-    return &S3Location{
-        Bucket: ViewerAssetsBucket,
-        Key:    assetKey,
-    }, nil
+// isS3URL checks if the host is an S3 URL
+func isS3URL(host string) bool {
+    // Check various S3 URL patterns
+    // Patterns include:
+    // - bucket.s3.amazonaws.com
+    // - bucket.s3.region.amazonaws.com  
+    // - bucket.s3-region.amazonaws.com (legacy)
+    // - s3.amazonaws.com
+    // - s3.region.amazonaws.com
+    // - s3-accelerate patterns
+    return contains(host, ".s3.amazonaws.com") ||
+           contains(host, ".s3-") || // Legacy S3 URLs
+           contains(host, "s3.amazonaws.com") ||
+           contains(host, ".s3.") && contains(host, ".amazonaws.com") || // Regional S3 URLs like s3.us-west-2.amazonaws.com
+           contains(host, "s3-accelerate.amazonaws.com") ||
+           contains(host, "s3-accelerate.dualstack.amazonaws.com")
 }
 
-// generatePresignedURL generates a presigned URL for the given S3 location
-func (h *S3ProxyHandler) generatePresignedURL(ctx context.Context, location *S3Location, method string) (string, error) {
-    // Load AWS configuration
-    cfg, err := config.LoadDefaultConfig(ctx)
-    if err != nil {
-        return "", fmt.Errorf("failed to load AWS config: %w", err)
+// contains is a simple string contains helper
+func contains(s, substr string) bool {
+    return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || len(substr) < len(s) && containsMiddle(s, substr)))
+}
+
+// containsMiddle checks if substr is in the middle of s
+func containsMiddle(s, substr string) bool {
+    for i := 0; i <= len(s)-len(substr); i++ {
+        if s[i:i+len(substr)] == substr {
+            return true
+        }
     }
-
-    // Create S3 client
-    s3Client := s3.NewFromConfig(cfg)
-
-    // Create presigner
-    presigner := s3.NewPresignClient(s3Client)
-
-    // Generate presigned URL based on method
-    var presignedReq *v4.PresignedHTTPRequest
-
-    switch method {
-    case http.MethodGet:
-        presignedReq, err = presigner.PresignGetObject(ctx, &s3.GetObjectInput{
-            Bucket: aws.String(location.Bucket),
-            Key:    aws.String(location.Key),
-        }, func(opts *s3.PresignOptions) {
-            opts.Expires = time.Duration(3600 * time.Second) // 1 hour expiry
-        })
-    case http.MethodHead:
-        // For HEAD requests, we need to use GetObject presigner but the actual request will be HEAD
-        presignedReq, err = presigner.PresignGetObject(ctx, &s3.GetObjectInput{
-            Bucket: aws.String(location.Bucket),
-            Key:    aws.String(location.Key),
-        }, func(opts *s3.PresignOptions) {
-            opts.Expires = time.Duration(3600 * time.Second) // 1 hour expiry
-        })
-        // Note: The caller will need to use HEAD method with this URL
-    default:
-        return "", fmt.Errorf("unsupported method for presigned URL: %s", method)
-    }
-
-    if err != nil {
-        return "", fmt.Errorf("failed to generate presigned URL: %w", err)
-    }
-
-    return presignedReq.URL, nil
+    return false
 }
 
 // buildCORSHeaders returns standard CORS headers
@@ -354,14 +263,14 @@ func (h *S3ProxyHandler) buildCORSHeaders() map[string]string {
     return map[string]string{
         "Access-Control-Allow-Origin":   "*",
         "Access-Control-Allow-Methods":  "GET, HEAD, OPTIONS",
-        "Access-Control-Allow-Headers":  "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Allow-Headers":  "Content-Type, Range, Origin, Accept",
         "Access-Control-Expose-Headers": "Content-Length, Content-Type, Content-Range, ETag, Last-Modified, Accept-Ranges",
     }
 }
 
-// forwardS3Headers forwards relevant headers from S3 response that DuckDB needs
+// forwardS3Headers forwards relevant headers from S3 response
 func (h *S3ProxyHandler) forwardS3Headers(resp *http.Response, headers map[string]string) {
-    // Forward S3 response headers that are essential for DuckDB and other clients
+    // Forward S3 response headers that are essential for clients
     headersToForward := []string{
         "Content-Type",
         "Content-Length", 
@@ -380,4 +289,3 @@ func (h *S3ProxyHandler) forwardS3Headers(resp *http.Response, headers map[strin
         }
     }
 }
-

--- a/lambda/service/handler/s3proxy_test.go
+++ b/lambda/service/handler/s3proxy_test.go
@@ -2,664 +2,314 @@ package handler
 
 import (
     "context"
-    "database/sql"
-    "fmt"
     "net/http"
-    "net/http/httptest"
-    "os"
-    "strings"
+    "net/url"
     "testing"
-    "time"
 
-    "github.com/pennsieve/packages-service/api/store"
-    "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/role"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/user"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
-    "github.com/stretchr/testify/suite"
-
-    // Import postgres driver
-    _ "github.com/lib/pq"
 )
 
-// S3ProxyTestSuite contains tests for S3Proxy handler using real database
-type S3ProxyTestSuite struct {
-    suite.Suite
-    db     *sql.DB
-    orgId  int
-    claims *authorizer.Claims
-}
-
-func (suite *S3ProxyTestSuite) SetupSuite() {
-    // Connect to test database using the same approach as working tests
-    pgConfig := &store.PostgresConfig{
-        Host:     getEnvOrDefault("POSTGRES_HOST", "localhost"),
-        Port:     getEnvOrDefault("POSTGRES_PORT", "5432"),
-        User:     getEnvOrDefault("POSTGRES_USER", "postgres"),
-        Password: getEnvOrDefault("POSTGRES_PASSWORD", "password"),
-        DBName:   getEnvOrDefault("PENNSIEVE_DB", "postgres"),
-        SSLMode:  getEnvOrDefault("POSTGRES_SSL_MODE", "disable"),
-    }
-
-    db, err := pgConfig.Open()
-    require.NoError(suite.T(), err)
-
-    // Retry database connection with backoff
-    err = suite.waitForDatabase(db)
-    if err != nil {
-        suite.T().Skipf("Database not available: %v", err)
-        return
-    }
-
-    suite.db = db
-    suite.orgId = 1 // Test organization
-
-    // Create test claims
-    suite.claims = &authorizer.Claims{
-        UserClaim: &user.Claim{
-            Id:           101,
-            NodeId:       "N:user:101",
-            IsSuperAdmin: false,
-        },
-        OrgClaim: &organization.Claim{
-            IntId:  int64(suite.orgId),
-            NodeId: "N:organization:1",
-            Role:   pgdb.Owner,
-        },
-        DatasetClaim: &dataset.Claim{
-            Role:   role.Editor,
-            NodeId: "N:dataset:1234",
-            IntId:  1234,
-        },
-    }
-
-    // Set up global database connection for handler
-    PennsieveDB = db
-}
-
-func (suite *S3ProxyTestSuite) TearDownSuite() {
-    if suite.db != nil {
-        suite.db.Close()
-    }
-}
-
-func (suite *S3ProxyTestSuite) SetupTest() {
-    // Clean up test data before each test
-    suite.cleanupTestData()
-}
-
-func (suite *S3ProxyTestSuite) TearDownTest() {
-    // Clean up test data after each test
-    suite.cleanupTestData()
-}
-
-func (suite *S3ProxyTestSuite) cleanupTestData() {
-    if suite.db == nil {
-        return
-    }
-
-    // Clean up files and packages tables - but preserve main test dataset N:dataset:1234
-    query := fmt.Sprintf(`DELETE FROM "%d".files WHERE s3_bucket LIKE 'test-%%'`, suite.orgId)
-    suite.db.Exec(query)
-
-    query = fmt.Sprintf(`DELETE FROM "%d".packages WHERE node_id LIKE 'N:package:test-%%'`, suite.orgId)
-    suite.db.Exec(query)
-
-    // Clean up only temporary test datasets (not the main N:dataset:1234)
-    query = fmt.Sprintf(`DELETE FROM "%d".datasets WHERE node_id LIKE 'N:dataset:test-%%'`, suite.orgId)
-    suite.db.Exec(query)
-}
-
-func (suite *S3ProxyTestSuite) createTestPackageWithFile(nodeId, bucket, key string) int64 {
-    // First ensure we have a dataset - use INSERT ... ON CONFLICT with primary key
-    var datasetId int64
-    
-    // Try to get existing dataset first
-    err := suite.db.QueryRow(fmt.Sprintf(`
-		SELECT id FROM "%d".datasets WHERE node_id = $1
-	`, suite.orgId), "N:dataset:1234").Scan(&datasetId)
-    
-    if err != nil {
-        // Dataset doesn't exist, create it with a specific ID to avoid conflicts
-        err = suite.db.QueryRow(fmt.Sprintf(`
-			INSERT INTO "%d".datasets (id, node_id, name, state, status_id, created_at, updated_at)
-			VALUES (9999, $1, 'Test Dataset', 'READY'::text, 1, NOW(), NOW())
-			ON CONFLICT (id) DO UPDATE SET 
-				node_id = EXCLUDED.node_id,
-				updated_at = NOW()
-			RETURNING id
-		`, suite.orgId), "N:dataset:1234").Scan(&datasetId)
-        require.NoError(suite.T(), err)
-    }
-
-    // Insert test package with all required fields
-    packageQuery := fmt.Sprintf(`
-		INSERT INTO "%d".packages (name, type, state, node_id, dataset_id, owner_id, size, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
-		RETURNING id
-	`, suite.orgId)
-
-    var packageId int64
-    err = suite.db.QueryRow(packageQuery, "test-package", "Package", "READY", nodeId, datasetId, 101, 1024).Scan(&packageId)
-    require.NoError(suite.T(), err)
-
-    // Insert test file with all required fields
-    fileQuery := fmt.Sprintf(`
-		INSERT INTO "%d".files (package_id, name, file_type, s3_bucket, s3_key, object_type, size, processing_state, uploaded_state, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
-	`, suite.orgId)
-
-    _, err = suite.db.Exec(fileQuery, packageId, "test-file.txt", 1, bucket, key, "source", 1024, "processed", "Uploaded")
-    require.NoError(suite.T(), err)
-
-    return packageId
-}
-
-func (suite *S3ProxyTestSuite) TestHandleOptions() {
-    req := newTestRequest("OPTIONS", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": "N:package:test-123",
+func TestS3ProxyHandleOptions(t *testing.T) {
+    req := newTestRequest("OPTIONS", "/proxy/s3", "test-request-id", map[string]string{
+        "presigned_url": "https://test-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256",
     }, "")
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
+    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)} // No claims needed for unauthenticated endpoint
 
     resp, err := handler.handleOptions(context.Background())
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusNoContent, resp.StatusCode)
-    assert.Equal(suite.T(), "*", resp.Headers["Access-Control-Allow-Origin"])
-    assert.Equal(suite.T(), "GET, HEAD, OPTIONS", resp.Headers["Access-Control-Allow-Methods"])
-    assert.Equal(suite.T(), "Authorization, Content-Type, Range, Origin, Accept", resp.Headers["Access-Control-Allow-Headers"])
-    assert.Equal(suite.T(), "3600", resp.Headers["Access-Control-Max-Age"])
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+    assert.Equal(t, "*", resp.Headers["Access-Control-Allow-Origin"])
+    assert.Equal(t, "GET, HEAD, OPTIONS", resp.Headers["Access-Control-Allow-Methods"])
+    assert.Equal(t, "Content-Type, Range, Origin, Accept", resp.Headers["Access-Control-Allow-Headers"])
+    assert.Equal(t, "3600", resp.Headers["Access-Control-Max-Age"])
 }
 
-func (suite *S3ProxyTestSuite) TestHandleGetMissingPackageId() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-    }, "")
+func TestS3ProxyHandleGetMissingURL(t *testing.T) {
+    req := newTestRequest("GET", "/proxy/s3", "test-request-id", map[string]string{}, "")
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
+    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
 
     resp, err := handler.handleGet(context.Background())
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "missing required 'package_id' query parameter")
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+    assert.Contains(t, resp.Body, "missing required 'presigned_url' query parameter")
 }
 
-func (suite *S3ProxyTestSuite) TestHandleGetMissingDatasetId() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "package_id": "N:package:test-123",
+func TestS3ProxyHandleGetInvalidURL(t *testing.T) {
+    tests := []struct {
+        name        string
+        presignedURL string
+        expectedError string
+    }{
+        {
+            name:          "Not a URL",
+            presignedURL:  "not-a-url",
+            expectedError: "invalid presigned URL",
+        },
+        {
+            name:          "HTTP instead of HTTPS",
+            presignedURL:  "http://test-bucket.s3.amazonaws.com/test-key",
+            expectedError: "URL must use HTTPS scheme",
+        },
+        {
+            name:          "Not an S3 URL",
+            presignedURL:  "https://example.com/test-key",
+            expectedError: "URL must be an S3 URL",
+        },
+        {
+            name:          "Missing signature parameters",
+            presignedURL:  "https://test-bucket.s3.amazonaws.com/test-key",
+            expectedError: "URL does not appear to be a valid presigned URL",
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            req := newTestRequest("GET", "/proxy/s3", "test-request-id", map[string]string{
+                "presigned_url": tt.presignedURL,
+            }, "")
+
+            handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
+
+            resp, err := handler.handleGet(context.Background())
+
+            require.NoError(t, err)
+            assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+            assert.Contains(t, resp.Body, tt.expectedError)
+        })
+    }
+}
+
+func TestS3ProxyHandleGetValidURL(t *testing.T) {
+    validURL := "https://test-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test"
+    
+    req := newTestRequest("GET", "/proxy/s3", "test-request-id", map[string]string{
+        "presigned_url": validURL,
     }, "")
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
+    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
 
     resp, err := handler.handleGet(context.Background())
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "missing required 'dataset_id' query parameter")
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+    assert.Equal(t, validURL, resp.Headers["Location"])
+    assert.Equal(t, "*", resp.Headers["Access-Control-Allow-Origin"])
 }
 
-func (suite *S3ProxyTestSuite) TestHandleGetPackageNotFound() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": "N:package:nonexistent",
-    }, "")
+func TestS3ProxyHandleHeadMissingURL(t *testing.T) {
+    req := newTestRequest("HEAD", "/proxy/s3", "test-request-id", map[string]string{}, "")
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    resp, err := handler.handleGet(context.Background())
-
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusInternalServerError, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "failed to get S3 location")
-}
-
-func (suite *S3ProxyTestSuite) TestHandleGetWithMockS3() {
-    // Create test package and file
-    packageNodeId := "N:package:test-123"
-    testBucket := "test-bucket"
-    testKey := "test-key"
-
-    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
-
-    // Create mock S3 server
-    testContent := "Hello, World!"
-    mockS3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        // Verify the request contains our test bucket and key in the path
-        if r.URL.Path == "/test-bucket/test-key" || r.URL.Path == fmt.Sprintf("/%s/%s", testBucket, testKey) {
-            w.Header().Set("Content-Type", "text/plain")
-            w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testContent)))
-            w.Header().Set("ETag", `"test-etag"`)
-            w.WriteHeader(http.StatusOK)
-            w.Write([]byte(testContent))
-        } else {
-            w.WriteHeader(http.StatusNotFound)
-        }
-    }))
-    defer mockS3Server.Close()
-
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": packageNodeId,
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    // Mock the generatePresignedURL method to return our test server URL
-    originalHandler := handler
-
-    // For this test, we'll test just the database query part
-    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
-
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
-    assert.Equal(suite.T(), testKey, s3Location.Key)
-
-    // Test CORS headers method
-    corsHeaders := originalHandler.buildCORSHeaders()
-    assert.Equal(suite.T(), "*", corsHeaders["Access-Control-Allow-Origin"])
-    assert.Equal(suite.T(), "GET, HEAD, OPTIONS", corsHeaders["Access-Control-Allow-Methods"])
-}
-
-func (suite *S3ProxyTestSuite) TestHandleHeadMissingPackageId() {
-    req := newTestRequest("HEAD", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
+    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
 
     resp, err := handler.handleHead(context.Background())
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusBadRequest, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "missing required 'package_id' query parameter")
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+    assert.Contains(t, resp.Body, "missing required 'presigned_url' query parameter")
 }
 
-func (suite *S3ProxyTestSuite) TestGetS3LocationForPackage() {
-    // Create test package and file
-    packageNodeId := "N:package:test-456"
-    testBucket := "test-bucket-2"
-    testKey := "test-key-2"
+func TestS3ProxyValidatePresignedURL(t *testing.T) {
+    handler := S3ProxyHandler{}
 
-    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
+    tests := []struct {
+        name        string
+        url         string
+        shouldError bool
+    }{
+        {
+            name:        "Valid S3 presigned URL with AWS4 signature",
+            url:         "https://test-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldError: false,
+        },
+        {
+            name:        "Valid S3 presigned URL with AWS2 signature",
+            url:         "https://test-bucket.s3.amazonaws.com/test-key?AWSAccessKeyId=test&Signature=test",
+            shouldError: false,
+        },
+        {
+            name:        "Valid S3 URL with region",
+            url:         "https://test-bucket.s3.us-west-2.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldError: false,
+        },
+        {
+            name:        "Invalid - not HTTPS",
+            url:         "http://test-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+            shouldError: true,
+        },
+        {
+            name:        "Invalid - not S3",
+            url:         "https://example.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+            shouldError: true,
+        },
+        {
+            name:        "Invalid - missing signature",
+            url:         "https://test-bucket.s3.amazonaws.com/test-key",
+            shouldError: true,
+        },
+    }
 
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{}, "")
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
-
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
-    assert.Equal(suite.T(), testKey, s3Location.Key)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := handler.validatePresignedURL(tt.url)
+            if tt.shouldError {
+                assert.Error(t, err)
+            } else {
+                assert.NoError(t, err)
+            }
+        })
+    }
 }
 
-func (suite *S3ProxyTestSuite) TestGetS3LocationForNonexistentPackage() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{}, "")
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    _, err := handler.getS3LocationForPackage(context.Background(), "N:package:nonexistent", "N:dataset:1234")
-
-    assert.Error(suite.T(), err)
-    assert.Contains(suite.T(), err.Error(), "package not found")
-}
-
-func (suite *S3ProxyTestSuite) TestBuildCORSHeaders() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{}, "")
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
+func TestS3ProxyBuildCORSHeaders(t *testing.T) {
+    handler := S3ProxyHandler{}
     headers := handler.buildCORSHeaders()
 
     expectedHeaders := map[string]string{
         "Access-Control-Allow-Origin":   "*",
         "Access-Control-Allow-Methods":  "GET, HEAD, OPTIONS",
-        "Access-Control-Allow-Headers":  "Authorization, Content-Type, Range, Origin, Accept",
+        "Access-Control-Allow-Headers":  "Content-Type, Range, Origin, Accept",
         "Access-Control-Expose-Headers": "Content-Length, Content-Type, Content-Range, ETag, Last-Modified, Accept-Ranges",
     }
 
     for key, expectedValue := range expectedHeaders {
-        assert.Equal(suite.T(), expectedValue, headers[key], "Header %s should match", key)
+        assert.Equal(t, expectedValue, headers[key], "Header %s should match", key)
     }
 }
 
-func (suite *S3ProxyTestSuite) TestForwardS3Headers() {
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{}, "")
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    // Create a mock HTTP response
-    resp := &http.Response{
-        Header: make(http.Header),
-    }
-    resp.Header.Set("Content-Type", "text/plain")
-    resp.Header.Set("Content-Length", "123")
-    resp.Header.Set("ETag", `"test-etag"`)
-    resp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
-    resp.Header.Set("Accept-Ranges", "bytes")
-    resp.Header.Set("X-Custom-Header", "should-not-be-forwarded") // This should not be forwarded
-
-    headers := make(map[string]string)
-    handler.forwardS3Headers(resp, headers)
-
-    // Check that expected headers are forwarded
-    assert.Equal(suite.T(), "text/plain", headers["Content-Type"])
-    assert.Equal(suite.T(), "123", headers["Content-Length"])
-    assert.Equal(suite.T(), `"test-etag"`, headers["ETag"])
-    assert.Equal(suite.T(), "Wed, 21 Oct 2015 07:28:00 GMT", headers["Last-Modified"])
-    assert.Equal(suite.T(), "bytes", headers["Accept-Ranges"])
-
-    // Check that custom headers are not forwarded
-    _, exists := headers["X-Custom-Header"]
-    assert.False(suite.T(), exists, "Custom headers should not be forwarded")
-}
-
-func (suite *S3ProxyTestSuite) TestHandleMethodNotAllowed() {
-    req := newTestRequest("PUT", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": "N:package:test-123",
+func TestS3ProxyMethodNotAllowed(t *testing.T) {
+    req := newTestRequest("PUT", "/proxy/s3", "test-request-id", map[string]string{
+        "presigned_url": "https://test-bucket.s3.amazonaws.com/test-key",
     }, "")
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
+    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
 
     resp, err := handler.handle(context.Background())
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusMethodNotAllowed, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "method PUT not allowed")
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+    assert.Contains(t, resp.Body, "method PUT not allowed")
 }
 
-func (suite *S3ProxyTestSuite) TestViewerAssetAccess() {
-    if suite.db == nil {
-        suite.T().Skip("Database not available for viewer asset test")
-        return
-    }
+func TestS3ProxyBucketAllowList(t *testing.T) {
+    // Save original and restore after test
+    originalAllowedBuckets := ProxyAllowedBuckets
+    defer func() {
+        ProxyAllowedBuckets = originalAllowedBuckets
+    }()
 
-    // Set up ViewerAssetsBucket for testing
-    originalBucket := ViewerAssetsBucket
-    ViewerAssetsBucket = "test-viewer-assets-bucket"
-    defer func() { ViewerAssetsBucket = originalBucket }()
-
-    // Create test package and dataset
-    packageNodeId := "N:package:test-asset-pkg"
-    datasetNodeId := "N:dataset:1234"
-
-    suite.createTestPackageWithFile(packageNodeId, "original-bucket", "original-key")
-
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": datasetNodeId,
-        "package_id": packageNodeId,
-        "path":       "preview/thumbnail.jpg",
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    // Test the getS3LocationForViewerAsset function directly
-    s3Location, err := handler.getS3LocationForViewerAsset(context.Background(), packageNodeId, datasetNodeId, "preview/thumbnail.jpg")
-
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), "test-viewer-assets-bucket", s3Location.Bucket)
-
-    // Expected format: O{WorkspaceIntId}/D{DatasetIntId}/P{PackageIntId}/{AssetPath}
-    // Get the actual dataset internal ID from the database
-    var actualDatasetIntId int64
-    err = suite.db.QueryRow(fmt.Sprintf(`SELECT id FROM "%d".datasets WHERE node_id = $1`, suite.orgId), datasetNodeId).Scan(&actualDatasetIntId)
-    require.NoError(suite.T(), err)
-
-    expectedKeyPrefix := fmt.Sprintf("O%d/D%d/P", suite.orgId, actualDatasetIntId)
-    assert.True(suite.T(), strings.HasPrefix(s3Location.Key, expectedKeyPrefix), "Key should start with %s, but got: %s", expectedKeyPrefix, s3Location.Key)
-    assert.True(suite.T(), strings.HasSuffix(s3Location.Key, "/preview/thumbnail.jpg"), "Key should end with asset path")
-}
-
-func (suite *S3ProxyTestSuite) TestViewerAssetAccessUnauthorized() {
-    if suite.db == nil {
-        suite.T().Skip("Database not available for viewer asset unauthorized test")
-        return
-    }
-
-    // Set up ViewerAssetsBucket for testing
-    originalBucket := ViewerAssetsBucket
-    ViewerAssetsBucket = "test-viewer-assets-bucket"
-    defer func() { ViewerAssetsBucket = originalBucket }()
-
-    // Try to access viewer asset for non-existent package
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": "N:package:nonexistent",
-        "path":       "preview/thumbnail.jpg",
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    _, err := handler.getS3LocationForViewerAsset(context.Background(), "N:package:nonexistent", "N:dataset:1234", "preview/thumbnail.jpg")
-
-    assert.Error(suite.T(), err)
-    assert.Contains(suite.T(), err.Error(), "package not found or does not belong to specified dataset")
-}
-
-func (suite *S3ProxyTestSuite) TestViewerAssetBucketNotConfigured() {
-    // Set ViewerAssetsBucket to empty to test error handling
-    originalBucket := ViewerAssetsBucket
-    ViewerAssetsBucket = ""
-    defer func() { ViewerAssetsBucket = originalBucket }()
-
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": "N:package:test",
-        "path":       "preview/thumbnail.jpg",
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    _, err := handler.getS3LocationForViewerAsset(context.Background(), "N:package:test", "N:dataset:1234", "preview/thumbnail.jpg")
-
-    assert.Error(suite.T(), err)
-    assert.Contains(suite.T(), err.Error(), "viewer assets bucket not configured")
-}
-
-func (suite *S3ProxyTestSuite) TestHandleGetWithPathParameter() {
-    // Create test package and file
-    packageNodeId := "N:package:test-with-path"
-    testBucket := "test-bucket"
-    testKey := "test-key"
-
-    suite.createTestPackageWithFile(packageNodeId, testBucket, testKey)
-
-    // Test GET request without path (should use original package file logic)
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": "N:dataset:1234",
-        "package_id": packageNodeId,
-    }, "")
-
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, suite.claims)}
-
-    s3Location, err := handler.getS3LocationForPackage(context.Background(), packageNodeId, "N:dataset:1234")
-
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), testBucket, s3Location.Bucket)
-    assert.Equal(suite.T(), testKey, s3Location.Key)
-}
-
-func (suite *S3ProxyTestSuite) TestCrossDatasetAccessDenied() {
-    if suite.db == nil {
-        suite.T().Skip("Database not available for cross-dataset access test")
-        return
-    }
-
-    // Use org ID from suite setup
-    orgId := int64(suite.orgId)
-
-    // Create unique node IDs to avoid conflicts with current timestamp + random component
-    timestamp := fmt.Sprintf("%d-%d", time.Now().UnixNano(), time.Now().Unix())
-    dataset1NodeId := fmt.Sprintf("N:dataset:test-unauthorized-%s", timestamp)
-    dataset2NodeId := fmt.Sprintf("N:dataset:test-authorized-%s", timestamp)
-    packageNodeId := fmt.Sprintf("N:package:test-unauthorized-pkg-%s", timestamp)
-
-    // More thorough cleanup before test to avoid any ID conflicts
-    suite.cleanupTestData()
-    
-    // Delete everything in reverse dependency order to avoid foreign key violations
-    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".files WHERE s3_bucket LIKE 'test-%%' OR s3_bucket = 'test-unauthorized-bucket'`, orgId))
-    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".packages WHERE node_id LIKE 'N:package:test-%%'`, orgId))
-    suite.db.Exec(fmt.Sprintf(`DELETE FROM "%d".datasets WHERE node_id LIKE 'N:dataset:test-%%' OR id = 9999 OR node_id LIKE '%%test-unauthorized%%' OR node_id LIKE '%%test-authorized%%'`, orgId))
-    
-    // Reset the auto-increment sequence to avoid conflicts
-    var maxId int
-    suite.db.QueryRow(fmt.Sprintf(`SELECT COALESCE(MAX(id), 0) FROM "%d".datasets`, orgId)).Scan(&maxId)
-    suite.db.Exec(fmt.Sprintf(`SELECT setval('"%d".datasets_id_seq', %d)`, orgId, maxId+1))
-
-    // Insert datasets using simple INSERT since we cleaned up beforehand
-    var dataset1Id, dataset2Id int64
-
-    err := suite.db.QueryRow(fmt.Sprintf(`
-		INSERT INTO "%d".datasets (node_id, name, state, status_id, created_at, updated_at)
-		VALUES ($1, 'Test Unauthorized Dataset', 'READY'::text, 1, NOW(), NOW())
-		RETURNING id
-	`, orgId), dataset1NodeId).Scan(&dataset1Id)
-    require.NoError(suite.T(), err)
-
-    err = suite.db.QueryRow(fmt.Sprintf(`
-		INSERT INTO "%d".datasets (node_id, name, state, status_id, created_at, updated_at)
-		VALUES ($1, 'Test Authorized Dataset', 'READY'::text, 1, NOW(), NOW())
-		RETURNING id
-	`, orgId), dataset2NodeId).Scan(&dataset2Id)
-    require.NoError(suite.T(), err)
-
-    // Create a package in dataset1 (unauthorized) without specifying ID
-    var packageId int64
-    err = suite.db.QueryRow(fmt.Sprintf(`
-		INSERT INTO "%d".packages (node_id, name, type, state, dataset_id, owner_id, size, created_at, updated_at)
-		VALUES ($1, 'Test Unauthorized Package', 'Package', 'READY', $2, 101, 1024, NOW(), NOW())
-		RETURNING id
-	`, orgId), packageNodeId, dataset1Id).Scan(&packageId)
-    require.NoError(suite.T(), err)
-
-    // Create a file for the package - use minimal required fields to avoid column type issues
-    _, err = suite.db.Exec(fmt.Sprintf(`
-		INSERT INTO "%d".files (package_id, name, file_type, s3_bucket, s3_key, object_type, processing_state, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
-	`, orgId), packageId, "test-unauthorized-file.txt", 1, "test-unauthorized-bucket", "test/unauthorized-file.txt", "source", "processed")
-    require.NoError(suite.T(), err)
-
-    // Create claims for user with access only to dataset2, NOT dataset1
-    unauthorizedClaims := &authorizer.Claims{
-        UserClaim: &user.Claim{
-            Id:           101,
-            NodeId:       "N:user:101",
-            IsSuperAdmin: false,
+    tests := []struct {
+        name           string
+        allowedBuckets []string
+        presignedURL   string
+        shouldAllow    bool
+    }{
+        {
+            name:           "No restrictions - all buckets allowed",
+            allowedBuckets: []string{},
+            presignedURL:   "https://any-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    true,
         },
-        OrgClaim: &organization.Claim{
-            IntId:  orgId,
-            NodeId: "N:organization:1",
-            Role:   pgdb.Owner,
+        {
+            name:           "Bucket in allowed list",
+            allowedBuckets: []string{"allowed-bucket", "another-bucket"},
+            presignedURL:   "https://allowed-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    true,
         },
-        DatasetClaim: &dataset.Claim{
-            Role:   role.Editor,
-            NodeId: dataset2NodeId, // User only has access to dataset2
-            IntId:  dataset2Id,
+        {
+            name:           "Bucket not in allowed list",
+            allowedBuckets: []string{"allowed-bucket", "another-bucket"},
+            presignedURL:   "https://forbidden-bucket.s3.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    false,
+        },
+        {
+            name:           "Regional URL with allowed bucket",
+            allowedBuckets: []string{"my-bucket"},
+            presignedURL:   "https://my-bucket.s3.us-west-2.amazonaws.com/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    true,
+        },
+        {
+            name:           "Path-style URL with allowed bucket",
+            allowedBuckets: []string{"my-bucket"},
+            presignedURL:   "https://s3.amazonaws.com/my-bucket/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    true,
+        },
+        {
+            name:           "Path-style URL with disallowed bucket",
+            allowedBuckets: []string{"allowed-bucket"},
+            presignedURL:   "https://s3.amazonaws.com/forbidden-bucket/test-key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=test",
+            shouldAllow:    false,
         },
     }
 
-    // Attempt to access package from dataset1 using credentials for dataset2
-    req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{
-        "dataset_id": dataset2NodeId, // Authorized dataset
-        "package_id": packageNodeId,  // Package from unauthorized dataset1
-    }, "")
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            ProxyAllowedBuckets = tt.allowedBuckets
 
-    handler := S3ProxyHandler{RequestHandler: *NewHandler(req, unauthorizedClaims)}
+            req := newTestRequest("GET", "/proxy/s3", "test-request-id", map[string]string{
+                "presigned_url": tt.presignedURL,
+            }, "")
 
-    resp, err := handler.handle(context.Background())
+            handler := S3ProxyHandler{RequestHandler: *NewHandler(req, nil)}
 
-    require.NoError(suite.T(), err)
-    assert.Equal(suite.T(), http.StatusInternalServerError, resp.StatusCode)
-    assert.Contains(suite.T(), resp.Body, "package not found, no associated file, or package does not belong to specified dataset")
-}
+            resp, err := handler.handleGet(context.Background())
+            require.NoError(t, err)
 
-// waitForDatabase waits for the database to be available with exponential backoff
-func (suite *S3ProxyTestSuite) waitForDatabase(db *sql.DB) error {
-    maxRetries := 10
-    backoff := time.Millisecond * 100
-
-    for i := 0; i < maxRetries; i++ {
-        err := db.Ping()
-        if err == nil {
-            return nil
-        }
-
-        suite.T().Logf("Database connection attempt %d failed: %v. Retrying in %v...", i+1, err, backoff)
-        time.Sleep(backoff)
-        backoff *= 2 // Exponential backoff
-
-        if backoff > time.Second*5 {
-            backoff = time.Second * 5 // Cap at 5 seconds
-        }
+            if tt.shouldAllow {
+                assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode, "URL should be allowed")
+                assert.Equal(t, tt.presignedURL, resp.Headers["Location"], "Should redirect to presigned URL")
+            } else {
+                assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "URL should be blocked")
+                assert.Contains(t, resp.Body, "is not in the allowed list", "Should indicate bucket is not allowed")
+            }
+        })
     }
-
-    // Final attempt
-    return db.Ping()
 }
 
-// Helper function to get environment variable with default
-func getEnvOrDefault(key, defaultValue string) string {
-    if value := os.Getenv(key); value != "" {
-        return value
-    }
-    return defaultValue
-}
-
-// TestS3ProxyTestSuite runs the test suite
-func TestS3ProxyTestSuite(t *testing.T) {
-    if testing.Short() {
-        t.Skip("Skipping database integration tests in short mode")
-    }
-    suite.Run(t, new(S3ProxyTestSuite))
-}
-
-// Individual unit tests that don't require database
-
-func TestS3ProxyHandleUnitTests(t *testing.T) {
-    // Test individual methods without database dependency
-    claims := &authorizer.Claims{
-        UserClaim: &user.Claim{
-            Id:           101,
-            NodeId:       "N:user:101",
-            IsSuperAdmin: false,
+func TestExtractBucketName(t *testing.T) {
+    tests := []struct {
+        name           string
+        url            string
+        expectedBucket string
+    }{
+        {
+            name:           "Virtual-hosted style",
+            url:            "https://my-bucket.s3.amazonaws.com/test-key",
+            expectedBucket: "my-bucket",
         },
-        OrgClaim: &organization.Claim{
-            IntId:  1,
-            NodeId: "N:organization:1",
-            Role:   pgdb.Owner,
+        {
+            name:           "Virtual-hosted style with region",
+            url:            "https://my-bucket.s3.us-west-2.amazonaws.com/test-key",
+            expectedBucket: "my-bucket",
         },
-        DatasetClaim: &dataset.Claim{
-            Role:   role.Editor,
-            NodeId: "N:dataset:1234",
-            IntId:  1234,
+        {
+            name:           "Path-style",
+            url:            "https://s3.amazonaws.com/my-bucket/test-key",
+            expectedBucket: "my-bucket",
+        },
+        {
+            name:           "Path-style with region",
+            url:            "https://s3.us-west-2.amazonaws.com/my-bucket/test-key",
+            expectedBucket: "my-bucket",
+        },
+        {
+            name:           "Legacy format",
+            url:            "https://my-bucket.s3-us-west-2.amazonaws.com/test-key",
+            expectedBucket: "my-bucket",
         },
     }
 
-    t.Run("handleOptions", func(t *testing.T) {
-        req := newTestRequest("OPTIONS", "/s3/proxy", "test-request-id", map[string]string{
-            "dataset_id": "N:dataset:1234",
-        }, "")
-
-        handler := S3ProxyHandler{RequestHandler: *NewHandler(req, claims)}
-
-        resp, err := handler.handleOptions(context.Background())
-
-        require.NoError(t, err)
-        assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-        assert.Equal(t, "*", resp.Headers["Access-Control-Allow-Origin"])
-    })
-
-    t.Run("buildCORSHeaders", func(t *testing.T) {
-        req := newTestRequest("GET", "/s3/proxy", "test-request-id", map[string]string{}, "")
-        handler := S3ProxyHandler{RequestHandler: *NewHandler(req, claims)}
-
-        headers := handler.buildCORSHeaders()
-        assert.Equal(t, "*", headers["Access-Control-Allow-Origin"])
-        assert.Equal(t, "GET, HEAD, OPTIONS", headers["Access-Control-Allow-Methods"])
-    })
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            parsedURL, err := url.Parse(tt.url)
+            require.NoError(t, err)
+            
+            bucket := extractBucketName(parsedURL)
+            assert.Equal(t, tt.expectedBucket, bucket, "Bucket name should match")
+        })
+    }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "service_lambda" {
       RDS_PROXY_ENDPOINT        = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint,
       RESTORE_PACKAGE_QUEUE_URL = aws_sqs_queue.restore_package_queue.url
       VIEWER_ASSETS_BUCKET      = aws_s3_bucket.package_assets.bucket
+      PROXY_ALLOWED_BUCKETS     = var.proxy_allowed_buckets
     }
   }
 }

--- a/terraform/packages-service.yml
+++ b/terraform/packages-service.yml
@@ -65,16 +65,16 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
-  /s3/proxy:
+  /presign/s3:
     get:
-      summary: Proxy for S3 package file requests
+      summary: Generate presigned URLs for S3 objects
       description: |
-        Generates presigned URLs and proxies requests to S3 with proper CORS handling.
-        This endpoint handles GET requests for package files and returns appropriate CORS headers
-        for clients that require OPTIONS preflight support (e.g., DuckDB, web browsers).
+        Authenticated endpoint that generates presigned URLs for S3 objects.
+        This endpoint validates dataset and package ownership before generating URLs.
+        Supports both package files and viewer assets.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
-      operationId: s3ProxyGet
+      operationId: presignS3Get
       security:
         - token_dataset_auth: [ ]
       tags:
@@ -131,13 +131,13 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
     options:
-      summary: CORS preflight for S3 package file requests
+      summary: CORS preflight for presigned URL generation
       description: |
         Handles OPTIONS preflight requests for CORS support.
-        Returns appropriate CORS headers to allow clients to access S3 package files.
+        Returns appropriate CORS headers for the presign endpoint.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
-      operationId: s3ProxyOptions
+      operationId: presignS3Options
       security:
         - token_dataset_auth: [ ]
       tags:
@@ -176,13 +176,13 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
     head:
-      summary: HEAD request proxy for S3 package file metadata
+      summary: HEAD request for S3 package file metadata
       description: |
-        Generates presigned URLs and proxies HEAD requests to S3 to retrieve metadata.
+        Authenticated endpoint that generates presigned URLs and retrieves S3 metadata.
         Clients like DuckDB use HEAD requests to get Content-Length before making range requests.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
-      operationId: s3ProxyHead
+      operationId: presignS3Head
       security:
         - token_dataset_auth: [ ]
       tags:
@@ -224,6 +224,121 @@ paths:
                 type: string
         '4XX':
           $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /proxy/s3:
+    get:
+      summary: Proxy S3 requests using presigned URLs
+      description: |
+        Unauthenticated proxy endpoint for S3 requests using presigned URLs.
+        This endpoint accepts a presigned URL as input and proxies the request,
+        handling CORS requirements for clients like DuckDB that cannot add custom headers.
+        GET requests return HTTP redirects to the presigned URL.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
+      operationId: proxyS3Get
+      tags:
+        - Packages Service
+      parameters:
+        - in: query
+          name: presigned_url
+          schema:
+            type: string
+          required: true
+          description: The presigned S3 URL to proxy
+      responses:
+        '307':
+          description: Temporary redirect to the presigned URL
+          headers:
+            Location:
+              schema:
+                type: string
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+        '4XX':
+          $ref: '#/components/responses/BadRequest'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    options:
+      summary: CORS preflight for S3 proxy requests
+      description: |
+        Handles OPTIONS preflight requests for the unauthenticated proxy endpoint.
+        Returns appropriate CORS headers to allow clients to access S3 through the proxy.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
+      operationId: proxyS3Options
+      tags:
+        - Packages Service
+      parameters:
+        - in: query
+          name: presigned_url
+          schema:
+            type: string
+          required: true
+          description: The presigned S3 URL (required for consistency but not used in OPTIONS)
+      responses:
+        '204':
+          description: Successful CORS preflight response
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+            Access-Control-Max-Age:
+              schema:
+                type: string
+        '4XX':
+          $ref: '#/components/responses/BadRequest'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    head:
+      summary: HEAD request proxy for S3 metadata
+      description: |
+        Unauthenticated proxy endpoint that forwards HEAD requests to S3 using presigned URLs.
+        Returns S3 metadata headers directly (not a redirect) for clients like DuckDB.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
+      operationId: proxyS3Head
+      tags:
+        - Packages Service
+      parameters:
+        - in: query
+          name: presigned_url
+          schema:
+            type: string
+          required: true
+          description: The presigned S3 URL to retrieve metadata from
+      responses:
+        '200':
+          description: Successful HEAD response with S3 metadata
+          headers:
+            Content-Length:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            Accept-Ranges:
+              schema:
+                type: string
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+        '4XX':
+          $ref: '#/components/responses/BadRequest'
         '5XX':
           $ref: '#/components/responses/Error'
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,6 +18,11 @@ variable "lambda_bucket" {
 
 variable "api_domain_name" {}
 
+variable "proxy_allowed_buckets" {
+  description = "Comma-separated list of S3 bucket names allowed for the unauthenticated proxy endpoint. Leave empty to allow all buckets."
+  type        = string
+  default     = ""
+}
 
 locals {
   common_tags = {


### PR DESCRIPTION
Refactoring Service to have:
1) Authenticated endpoint to generate presigned urls for Package Files, and Package File Assets
2) Unauthenticated endpoint for proxying presigned URLS in specific buckets (for DuckDB)