### PR TITLE
868hyf0px add missing buckets

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -102,8 +102,6 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
       data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,
       "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn}/*",
-      data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn,
-      "${data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn}/*",
       data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
       "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       "arn:aws:s3:::pennsieve-*-package-*/*"
@@ -271,8 +269,6 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
-      data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn,
-      "${data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn}/*",
       data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
       "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -36,8 +36,8 @@ resource "aws_iam_policy" "packages_service_lambda_iam_policy" {
 data "aws_iam_policy_document" "packages_service_iam_policy_document" {
 
   statement {
-    sid     = "PackagesServiceLambdaLogsPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaLogsPermissions"
+    effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
@@ -49,8 +49,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaEC2Permissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaEC2Permissions"
+    effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DescribeNetworkInterfaces",
@@ -62,8 +62,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaRDSPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaRDSPermissions"
+    effect = "Allow"
     actions = [
       "rds-db:connect"
     ]
@@ -85,21 +85,34 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaS3Permissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaS3Permissions"
+    effect = "Allow"
     actions = [
       "s3:GetObject",
       "s3:HeadObject"
     ]
     resources = [
-      "arn:aws:s3:::pennsieve-*-storage-*/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
+      data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,
+      "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn}/*",
+      data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       "arn:aws:s3:::pennsieve-*-package-*/*"
     ]
   }
 
   statement {
-    sid     = "PackagesServiceLambdaSSMPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaSSMPermissions"
+    effect = "Allow"
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
@@ -111,8 +124,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaSecretsManagerPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaSecretsManagerPermissions"
+    effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
@@ -123,8 +136,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaKMSDecryptPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaKMSDecryptPermissions"
+    effect = "Allow"
     actions = [
       "kms:Decrypt"
     ]
@@ -174,8 +187,8 @@ resource "aws_iam_policy" "restore_package_lambda_iam_policy" {
 data "aws_iam_policy_document" "restore_package_iam_policy_document" {
 
   statement {
-    sid     = "RestorePackageLambdaLogsPermissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaLogsPermissions"
+    effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
@@ -187,8 +200,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
   }
 
   statement {
-    sid     = "RestorePackageLambdaEC2Permissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaEC2Permissions"
+    effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DescribeNetworkInterfaces",
@@ -200,8 +213,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
   }
 
   statement {
-    sid     = "RestorePackageLambdaRDSPermissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaRDSPermissions"
+    effect = "Allow"
     actions = [
       "rds-db:connect"
     ]
@@ -258,6 +271,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.ember_pennsieve_storage_bucket_arn}/*",
       data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
       "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,


### PR DESCRIPTION
The service Lambda needs read permission on several bucket's missing from it's IAM policy in order to create usable presigned URLs. PR adds these buckets.


non-prod Terraform plan
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.packages_service.aws_cloudwatch_event_target.cloudfront_key_cleanup_target will be updated in-place
  ~ resource "aws_cloudwatch_event_target" "cloudfront_key_cleanup_target" {
        id             = "dev-packages-service-cloudfront-key-cleanup-CloudFrontKeyCleanupTarget"
      ~ input          = jsonencode(
            {
              - ClientRequestToken = "scheduled-cleanup-2026-03-18-2036"
              - SecretId           = "arn:aws:secretsmanager:us-east-1:941165240011:secret:dev-packages-service-cloudfront-signing-keys-HLr9RM"
              - Step               = "cleanupOldKeys"
            }
        ) -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # module.packages_service.aws_iam_policy.packages_service_lambda_iam_policy will be updated in-place
  ~ resource "aws_iam_policy" "packages_service_lambda_iam_policy" {
        id               = "arn:aws:iam::941165240011:policy/dev-packages-service-lambda-iam-policy-use1"
        name             = "dev-packages-service-lambda-iam-policy-use1"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                    # (3 unchanged elements hidden)
                    {
                        Action   = [
                            "sqs:SendMessage",
                            "sqs:GetQueueUrl",
                        ]
                        Effect   = "Allow"
                        Resource = "arn:aws:sqs:us-east-1:941165240011:dev-restore-package-queue-use1"
                        Sid      = "PackageServiceLambdaWriteToEventsPermission"
                    },
                  ~ {
                      ~ Resource = [
                          - "arn:aws:s3:::pennsieve-*-storage-*/*",
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1/*",
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1",
                          + "arn:aws:s3:::pennsieve-dev-storage-use1/*",
                          + "arn:aws:s3:::pennsieve-dev-storage-use1",
                          + "arn:aws:s3:::pennsieve-dev-storage-afs1/*",
                          + "arn:aws:s3:::pennsieve-dev-storage-afs1",
                            "arn:aws:s3:::pennsieve-*-package-*/*",
                          + "arn:aws:s3:::dev-sparc-storage-use1/*",
                          + "arn:aws:s3:::dev-sparc-storage-use1",
                          + "arn:aws:s3:::dev-rejoin-storage-use1/*",
                          + "arn:aws:s3:::dev-rejoin-storage-use1",
                          + "arn:aws:s3:::dev-precision-storage-use1/*",
                          + "arn:aws:s3:::dev-precision-storage-use1",
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = [
                            "ssm:GetParametersByPath",
                            "ssm:GetParameters",
                            "ssm:GetParameter",
                        ]
                        Effect   = "Allow"
                        Resource = "arn:aws:ssm:us-east-1:941165240011:parameter/dev/packages-service/*"
                        Sid      = "PackagesServiceLambdaSSMPermissions"
                    },
                    # (2 unchanged elements hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        tags             = {}
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```