### PR TITLE
868hjc75t bucket fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ A serverless microservice that provides secure access to package assets and data
 
 The Packages Service handles:
 - **Package restoration** from deleted/archived state
-- **Presigned URL generation** for secure S3 access
+- **Download manifest generation** for secure S3 access
 - **CloudFront signed URLs** for optimized content delivery
-- **Unauthenticated proxy** for cross-origin requests
 
 ## Architecture
 
@@ -55,23 +54,46 @@ POST /packages/restore?dataset_id=N:dataset:123
 }
 ```
 
-### 2. S3 Presigned URLs (`GET /presign/s3`)
-Generates presigned URLs for direct S3 access to package files and viewer assets.
+### 2. Download manifest with S3 Presigned URLs (`POST /download-manifest`)
+Generates a download manifest that includes presigned URLs for direct S3 access to package files.
 
 **Authentication**: Required (dataset-level permissions)
 
 **Request**:
 ```bash
-GET /packages/presign/s3?dataset_id=N:dataset:123&package_id=N:package:456&path=preview/thumbnail.jpg
+POST /packages/download-manifest?dataset_id=N:dataset:123
+{
+  "nodeIds": [
+    "string"
+  ]
+}
 ```
 
-**Response**: HTTP 307 redirect to presigned S3 URL
+**Response**:
+```json
+{
+  "header": {
+    "count": 0,
+    "size": 0
+  },
+  "data": [
+    {
+      "nodeId": "string",
+      "fileName": "string",
+      "packageName": "string",
+      "path": [
+        "string"
+      ],
+      "url": "string",
+      "size": 0,
+      "fileExtension": "string"
+    }
+  ]
+}
+```
 
 **Query Parameters**:
 - `dataset_id` (required): Dataset node ID
-- `package_id` (required): Package node ID  
-- `path` (optional): Path to viewer asset within package
-- `redirect` (optional): `false` to return JSON instead of redirect
 
 ### 3. CloudFront Signed URLs (`GET /cloudfront/sign`)
 Generates CloudFront signed URLs for optimized content delivery with CDN caching.
@@ -96,24 +118,6 @@ GET /packages/cloudfront/sign?dataset_id=N:dataset:123&package_id=N:package:456&
 - Optimized caching for Parquet files (30 days)
 - Private distribution (signed URLs required)
 - Better performance than direct S3 access
-
-### 4. S3 Proxy (`GET /proxy/s3`)
-Unauthenticated proxy for S3 requests using presigned URLs. Handles CORS for browser clients.
-
-**Authentication**: None required (validates presigned URL)
-
-**Request**:
-```bash
-GET /packages/proxy/s3?presigned_url=https://bucket.s3.amazonaws.com/key?X-Amz-Signature=...
-```
-
-**Response**: HTTP 307 redirect to presigned URL with CORS headers
-
-**Features**:
-- Validates presigned URL signatures
-- Bucket allowlist support via `PROXY_ALLOWED_BUCKETS` env var
-- CORS headers for browser compatibility
-- HEAD request support for metadata
 
 ## Infrastructure
 

--- a/api/models/download.go
+++ b/api/models/download.go
@@ -28,19 +28,20 @@ type DownloadManifestEntry struct {
 
 // PackageHierarchyRow represents a single row from the recursive package hierarchy query.
 type PackageHierarchyRow struct {
-	DatasetId        int
-	NodeIdPath       []string
-	PackageId        int64
-	NodeId           string
-	PackageType      string
-	PackageState     string
-	PackageNamePath  []string
-	PackageName      string
-	PackageFileCount int
-	FileId           int64
-	FileName         string
-	Size             int64
-	FileType         string
-	S3Bucket         string
-	S3Key            string
+	DatasetId            int
+	NodeIdPath           []string
+	PackageId            int64
+	NodeId               string
+	PackageType          string
+	PackageState         string
+	PackageNamePath      []string
+	PackageName          string
+	PackageFileCount     int
+	FileId               int64
+	FileName             string
+	Size                 int64
+	FileType             string
+	S3Bucket             string
+	S3Key                string
+	PublishedS3VersionId *string
 }

--- a/api/regions/regions.go
+++ b/api/regions/regions.go
@@ -1,0 +1,15 @@
+package regions
+
+import "strings"
+
+func ForBucket(bucketName string) string {
+	if strings.HasSuffix(bucketName, "-use1") {
+		return "us-east-1"
+	}
+	if strings.HasSuffix(bucketName, "-afs1") {
+		return "af-south-1"
+	}
+
+	return "us-east-1"
+
+}

--- a/api/regions/regions_test.go
+++ b/api/regions/regions_test.go
@@ -1,0 +1,21 @@
+package regions
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestForBucket(t *testing.T) {
+	for name, tt := range map[string]struct {
+		bucket   string
+		expected string
+	}{
+		"us-east-1 suffix":     {bucket: "pennsieve-dev-storage-use1", expected: "us-east-1"},
+		"af-south-1 suffix":    {bucket: "pennsieve-dev-storage-afs1", expected: "af-south-1"},
+		"no recognized suffix": {bucket: "pennsieve-dev-storage", expected: "us-east-1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ForBucket(tt.bucket))
+		})
+	}
+}

--- a/api/store/s3.go
+++ b/api/store/s3.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/pennsieve/packages-service/api/logging"
+	"github.com/pennsieve/packages-service/api/regions"
 )
 
 const maxDeleteObjects = 1000
@@ -101,6 +102,7 @@ func (s *s3Store) DeleteObjectsVersion(ctx context.Context, objInfos ...S3Object
 		}
 	}
 	for bucket, batches := range byBucket {
+		bucketRegion := regions.ForBucket(bucket)
 		for i, batch := range batches {
 			input := s3.DeleteObjectsInput{
 				Bucket: aws.String(bucket),
@@ -108,7 +110,9 @@ func (s *s3Store) DeleteObjectsVersion(ctx context.Context, objInfos ...S3Object
 					Objects: batch,
 				},
 			}
-			if output, err := s.Client.DeleteObjects(ctx, &input); err != nil {
+			if output, err := s.Client.DeleteObjects(ctx, &input, func(options *s3.Options) {
+				options.Region = bucketRegion
+			}); err != nil {
 				return response, fmt.Errorf("api/store/s3: error deleting batch %d of %d for bucket %s: %w", i, len(batches), bucket, err)
 			} else {
 				for _, success := range output.Deleted {

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1
+	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.7
 	github.com/pennsieve/packages-service/api v0.0.0
 	github.com/pennsieve/pennsieve-go-core v1.15.0
@@ -44,7 +45,6 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/sys v0.21.0 // indirect

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -10,10 +10,12 @@ require (
 	github.com/aws/aws-lambda-go v1.34.1
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.19
+	github.com/aws/aws-sdk-go-v2/credentials v1.18.23
 	github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign v1.9.13
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14
+	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1
 	github.com/lib/pq v1.10.7
 	github.com/pennsieve/packages-service/api v0.0.0
 	github.com/pennsieve/pennsieve-go-core v1.15.0
@@ -23,7 +25,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 // indirect
@@ -40,7 +41,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 // indirect
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pennsieve/packages-service/api/regions"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -72,13 +73,25 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 
 	var entries []models.DownloadManifestEntry
 	var totalSize int64
+	bucketNameToRegion := map[string]string{}
 
 	for _, row := range rows {
+		region, found := bucketNameToRegion[row.S3Bucket]
+		if !found {
+			region = regions.ForBucket(row.S3Bucket)
+			bucketNameToRegion[row.S3Bucket] = region
+		}
 		presignResult, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 			Bucket:                     aws.String(row.S3Bucket),
 			Key:                        aws.String(row.S3Key),
+			VersionId:                  row.PublishedS3VersionId,
 			ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, row.PackageName)),
-		}, s3.WithPresignExpires(180*time.Minute))
+		}, s3.WithPresignExpires(180*time.Minute),
+			func(options *s3.PresignOptions) {
+				options.ClientOptions = append(options.ClientOptions, func(options *s3.Options) {
+					options.Region = region
+				})
+			})
 		if err != nil {
 			h.logger.Errorf("failed to generate presigned URL for bucket=%s key=%s: %v", row.S3Bucket, row.S3Key, err)
 			return nil, fmt.Errorf("failed to generate presigned URL: %w", err)
@@ -158,7 +171,8 @@ func (h *DownloadManifestHandler) getPackageHierarchy(ctx context.Context, orgId
 			f.size,
 			f.file_type,
 			f.s3_bucket,
-			f.s3_key
+			f.s3_key,
+            f.published_s3_version_id
 		FROM parents
 		JOIN "%[1]d".files f ON f.package_id = parents.id
 		JOIN (
@@ -197,6 +211,7 @@ func (h *DownloadManifestHandler) getPackageHierarchy(ctx context.Context, orgId
 			&row.FileType,
 			&row.S3Bucket,
 			&row.S3Key,
+			&row.PublishedS3VersionId,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan hierarchy row: %w", err)
 		}

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/packages-service/api/regions"
 	"net/http"
 	"os"
@@ -101,7 +100,7 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 	var totalSize int64
 
 	presignDuration := 180 * time.Minute
-	bucketOptionsCache := NewBucketOptionsCache(STSClient, presignDuration, h.externalBucketConfig)
+	bucketOptionsCache := NewBucketOptionsCache(AssumeRoleClient, presignDuration, h.externalBucketConfig)
 
 	for _, row := range rows {
 		s3Bucket := row.S3Bucket
@@ -272,15 +271,15 @@ func (o BucketOptions) RequestPayer() types.RequestPayer {
 
 type BucketOptionsCache struct {
 	cache                map[string]BucketOptions
-	stsClient            *sts.Client
+	assumeRoleClient     stscreds.AssumeRoleAPIClient
 	presignDuration      time.Duration
 	externalBucketConfig ExternalBucketConfig
 }
 
-func NewBucketOptionsCache(stsClient *sts.Client, presignDuration time.Duration, externalBucketConfig ExternalBucketConfig) *BucketOptionsCache {
+func NewBucketOptionsCache(assumeRoleClient stscreds.AssumeRoleAPIClient, presignDuration time.Duration, externalBucketConfig ExternalBucketConfig) *BucketOptionsCache {
 	return &BucketOptionsCache{
 		cache:                make(map[string]BucketOptions),
-		stsClient:            stsClient,
+		assumeRoleClient:     assumeRoleClient,
 		presignDuration:      presignDuration,
 		externalBucketConfig: externalBucketConfig,
 	}
@@ -291,7 +290,7 @@ func (c *BucketOptionsCache) Get(bucketName string) BucketOptions {
 	if !found {
 		bucketOptions = BucketOptions{Region: regions.ForBucket(bucketName)}
 		if roleARN, isExternal := c.externalBucketConfig[bucketName]; isExternal {
-			credentialsProvider := aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(c.stsClient, roleARN, func(options *stscreds.AssumeRoleOptions) {
+			credentialsProvider := aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(c.assumeRoleClient, roleARN, func(options *stscreds.AssumeRoleOptions) {
 				options.RoleSessionName = "packages-service-presign-session"
 				options.Duration = c.presignDuration
 				options.Policy = aws.String(`{

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/packages-service/api/regions"
 	"net/http"
 	"os"
@@ -36,11 +37,6 @@ func ExternalBucketConfigFromEnv() (ExternalBucketConfig, error) {
 		return nil, fmt.Errorf("parsing %s value [%s]: %w", ExternalBucketsRoleMapKey, raw, err)
 	}
 	return m, nil
-}
-
-type BucketOptions struct {
-	Region              string
-	CredentialsProvider *aws.CredentialsCache
 }
 
 type DownloadManifestHandler struct {
@@ -103,8 +99,9 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 
 	var entries []models.DownloadManifestEntry
 	var totalSize int64
-	bucketNameToOptions := map[string]BucketOptions{}
+
 	presignDuration := 180 * time.Minute
+	bucketOptionsCache := NewBucketOptionsCache(STSClient, presignDuration, h.externalBucketConfig)
 
 	for _, row := range rows {
 		s3Bucket := row.S3Bucket
@@ -114,31 +111,7 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 			VersionId:                  row.PublishedS3VersionId,
 			ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, row.PackageName)),
 		}
-		bucketOptions, found := bucketNameToOptions[s3Bucket]
-		if !found {
-			bucketOptions = BucketOptions{Region: regions.ForBucket(s3Bucket)}
-			if roleARN, isExternal := h.externalBucketConfig[s3Bucket]; isExternal {
-				credentialsProvider := aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(STSClient, roleARN, func(options *stscreds.AssumeRoleOptions) {
-					options.RoleSessionName = "packages-service-presign-session"
-					options.Duration = presignDuration
-					options.Policy = aws.String(`{
-        				"Version": "2012-10-17",
-        				"Statement": [
-            				{
-                				"Effect": "Allow",
-                				"Action": [
-                    				"s3:GetObject",
-                    				"s3:GetObjectVersion"
-                				],
-								"Resource": "*"
-            				}
-        				]
-					}`)
-				}))
-				bucketOptions.CredentialsProvider = credentialsProvider
-			}
-			bucketNameToOptions[s3Bucket] = bucketOptions
-		}
+		bucketOptions := bucketOptionsCache.Get(s3Bucket)
 		// it's an external bucket, so set RequestPayer
 		if bucketOptions.CredentialsProvider != nil {
 			getObjectInput.RequestPayer = types.RequestPayerRequester
@@ -146,12 +119,7 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 
 		presignResult, err := presignClient.PresignGetObject(ctx, &getObjectInput, s3.WithPresignExpires(presignDuration),
 			func(options *s3.PresignOptions) {
-				options.ClientOptions = append(options.ClientOptions, func(options *s3.Options) {
-					options.Region = bucketOptions.Region
-					if bucketOptions.CredentialsProvider != nil {
-						options.Credentials = bucketOptions.CredentialsProvider
-					}
-				})
+				options.ClientOptions = append(options.ClientOptions, bucketOptions.S3Options())
 			})
 		if err != nil {
 			h.logger.Errorf("failed to generate presigned URL for bucket=%s key=%s: %v", s3Bucket, row.S3Key, err)
@@ -283,6 +251,65 @@ func (h *DownloadManifestHandler) getPackageHierarchy(ctx context.Context, orgId
 	}
 
 	return results, nil
+}
+
+type BucketOptions struct {
+	Region              string
+	CredentialsProvider *aws.CredentialsCache
+}
+
+func (o BucketOptions) S3Options() func(s3Options *s3.Options) {
+	return func(s3Options *s3.Options) {
+		s3Options.Region = o.Region
+		if o.CredentialsProvider != nil {
+			s3Options.Credentials = o.CredentialsProvider
+		}
+	}
+}
+
+type BucketOptionsCache struct {
+	cache                map[string]BucketOptions
+	stsClient            *sts.Client
+	presignDuration      time.Duration
+	externalBucketConfig ExternalBucketConfig
+}
+
+func NewBucketOptionsCache(stsClient *sts.Client, presignDuration time.Duration, externalBucketConfig ExternalBucketConfig) *BucketOptionsCache {
+	return &BucketOptionsCache{
+		cache:                make(map[string]BucketOptions),
+		stsClient:            stsClient,
+		presignDuration:      presignDuration,
+		externalBucketConfig: externalBucketConfig,
+	}
+}
+
+func (c *BucketOptionsCache) Get(bucketName string) BucketOptions {
+	bucketOptions, found := c.cache[bucketName]
+	if !found {
+		bucketOptions = BucketOptions{Region: regions.ForBucket(bucketName)}
+		if roleARN, isExternal := c.externalBucketConfig[bucketName]; isExternal {
+			credentialsProvider := aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(c.stsClient, roleARN, func(options *stscreds.AssumeRoleOptions) {
+				options.RoleSessionName = "packages-service-presign-session"
+				options.Duration = c.presignDuration
+				options.Policy = aws.String(`{
+        				"Version": "2012-10-17",
+        				"Statement": [
+            				{
+                				"Effect": "Allow",
+                				"Action": [
+                    				"s3:GetObject",
+                    				"s3:GetObjectVersion"
+                				],
+								"Resource": "*"
+            				}
+        				]
+					}`)
+			}))
+			bucketOptions.CredentialsProvider = credentialsProvider
+		}
+		c.cache[bucketName] = bucketOptions
+	}
+	return bucketOptions
 }
 
 // Common multi-dot extensions from the Pennsieve file type map.

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -26,16 +26,18 @@ type ExternalBucketConfig map[string]string
 
 const ExternalBucketsRoleMapKey = "EXTERNAL_BUCKETS_ROLE_MAP"
 
-func ExternalBucketConfigFromEnv() (ExternalBucketConfig, error) {
+func (h *DownloadManifestHandler) LoadExternalBucketConfigFromEnv() error {
 	raw := os.Getenv(ExternalBucketsRoleMapKey)
 	if raw == "" {
-		return nil, fmt.Errorf("%s not set", ExternalBucketsRoleMapKey)
+		return fmt.Errorf("%s not set", ExternalBucketsRoleMapKey)
 	}
 	m := make(map[string]string)
 	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		return nil, fmt.Errorf("parsing %s value [%s]: %w", ExternalBucketsRoleMapKey, raw, err)
+		return fmt.Errorf("parsing %s value [%s]: %w", ExternalBucketsRoleMapKey, raw, err)
 	}
-	return m, nil
+	h.externalBucketConfig = m
+	h.logger.Debugf("set %s: %s", ExternalBucketsRoleMapKey, m)
+	return nil
 }
 
 type DownloadManifestHandler struct {
@@ -46,11 +48,9 @@ type DownloadManifestHandler struct {
 func (h *DownloadManifestHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
 	switch h.method {
 	case "POST":
-		externalBucketConfig, err := ExternalBucketConfigFromEnv()
-		if err != nil {
+		if err := h.LoadExternalBucketConfigFromEnv(); err != nil {
 			return h.logAndBuildError(err.Error(), http.StatusInternalServerError), nil
 		}
-		h.externalBucketConfig = externalBucketConfig
 		return h.post(ctx)
 	default:
 		return h.logAndBuildError("method not allowed: "+h.method, http.StatusMethodNotAllowed), nil

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -105,19 +105,15 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 
 	for _, row := range rows {
 		s3Bucket := row.S3Bucket
-		getObjectInput := s3.GetObjectInput{
+		bucketOptions := bucketOptionsCache.Get(s3Bucket)
+
+		presignResult, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 			Bucket:                     aws.String(s3Bucket),
 			Key:                        aws.String(row.S3Key),
 			VersionId:                  row.PublishedS3VersionId,
+			RequestPayer:               bucketOptions.RequestPayer(),
 			ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, row.PackageName)),
-		}
-		bucketOptions := bucketOptionsCache.Get(s3Bucket)
-		// it's an external bucket, so set RequestPayer
-		if bucketOptions.CredentialsProvider != nil {
-			getObjectInput.RequestPayer = types.RequestPayerRequester
-		}
-
-		presignResult, err := presignClient.PresignGetObject(ctx, &getObjectInput, s3.WithPresignExpires(presignDuration),
+		}, s3.WithPresignExpires(presignDuration),
 			func(options *s3.PresignOptions) {
 				options.ClientOptions = append(options.ClientOptions, bucketOptions.S3Options())
 			})
@@ -265,6 +261,13 @@ func (o BucketOptions) S3Options() func(s3Options *s3.Options) {
 			s3Options.Credentials = o.CredentialsProvider
 		}
 	}
+}
+
+func (o BucketOptions) RequestPayer() types.RequestPayer {
+	if o.CredentialsProvider == nil {
+		return ""
+	}
+	return types.RequestPayerRequester
 }
 
 type BucketOptionsCache struct {

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/pennsieve/packages-service/api/regions"
 	"net/http"
 	"path/filepath"
@@ -85,6 +86,7 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 			Bucket:                     aws.String(row.S3Bucket),
 			Key:                        aws.String(row.S3Key),
 			VersionId:                  row.PublishedS3VersionId,
+			RequestPayer:               types.RequestPayerRequester,
 			ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, row.PackageName)),
 		}, s3.WithPresignExpires(180*time.Minute),
 			func(options *s3.PresignOptions) {

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/pennsieve/packages-service/api/regions"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -20,13 +22,40 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/permissions"
 )
 
+type ExternalBucketConfig map[string]string
+
+const ExternalBucketsRoleMapKey = "EXTERNAL_BUCKETS_ROLE_MAP"
+
+func ExternalBucketConfigFromEnv() (ExternalBucketConfig, error) {
+	raw := os.Getenv(ExternalBucketsRoleMapKey)
+	if raw == "" {
+		return nil, fmt.Errorf("%s not set", ExternalBucketsRoleMapKey)
+	}
+	m := make(map[string]string)
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("parsing %s value [%s]: %w", ExternalBucketsRoleMapKey, raw, err)
+	}
+	return m, nil
+}
+
+type BucketOptions struct {
+	Region              string
+	CredentialsProvider *aws.CredentialsCache
+}
+
 type DownloadManifestHandler struct {
 	RequestHandler
+	externalBucketConfig ExternalBucketConfig
 }
 
 func (h *DownloadManifestHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
 	switch h.method {
 	case "POST":
+		externalBucketConfig, err := ExternalBucketConfigFromEnv()
+		if err != nil {
+			return h.logAndBuildError(err.Error(), http.StatusInternalServerError), nil
+		}
+		h.externalBucketConfig = externalBucketConfig
 		return h.post(ctx)
 	default:
 		return h.logAndBuildError("method not allowed: "+h.method, http.StatusMethodNotAllowed), nil
@@ -74,28 +103,58 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 
 	var entries []models.DownloadManifestEntry
 	var totalSize int64
-	bucketNameToRegion := map[string]string{}
+	bucketNameToOptions := map[string]BucketOptions{}
+	presignDuration := 180 * time.Minute
 
 	for _, row := range rows {
-		region, found := bucketNameToRegion[row.S3Bucket]
-		if !found {
-			region = regions.ForBucket(row.S3Bucket)
-			bucketNameToRegion[row.S3Bucket] = region
-		}
-		presignResult, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-			Bucket:                     aws.String(row.S3Bucket),
+		s3Bucket := row.S3Bucket
+		getObjectInput := s3.GetObjectInput{
+			Bucket:                     aws.String(s3Bucket),
 			Key:                        aws.String(row.S3Key),
 			VersionId:                  row.PublishedS3VersionId,
-			RequestPayer:               types.RequestPayerRequester,
 			ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, row.PackageName)),
-		}, s3.WithPresignExpires(180*time.Minute),
+		}
+		bucketOptions, found := bucketNameToOptions[s3Bucket]
+		if !found {
+			bucketOptions = BucketOptions{Region: regions.ForBucket(s3Bucket)}
+			if roleARN, isExternal := h.externalBucketConfig[s3Bucket]; isExternal {
+				credentialsProvider := aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(STSClient, roleARN, func(options *stscreds.AssumeRoleOptions) {
+					options.RoleSessionName = "packages-service-presign-session"
+					options.Duration = presignDuration
+					options.Policy = aws.String(`{
+        				"Version": "2012-10-17",
+        				"Statement": [
+            				{
+                				"Effect": "Allow",
+                				"Action": [
+                    				"s3:GetObject",
+                    				"s3:GetObjectVersion"
+                				],
+								"Resource": "*"
+            				}
+        				]
+					}`)
+				}))
+				bucketOptions.CredentialsProvider = credentialsProvider
+			}
+			bucketNameToOptions[s3Bucket] = bucketOptions
+		}
+		// it's an external bucket, so set RequestPayer
+		if bucketOptions.CredentialsProvider != nil {
+			getObjectInput.RequestPayer = types.RequestPayerRequester
+		}
+
+		presignResult, err := presignClient.PresignGetObject(ctx, &getObjectInput, s3.WithPresignExpires(presignDuration),
 			func(options *s3.PresignOptions) {
 				options.ClientOptions = append(options.ClientOptions, func(options *s3.Options) {
-					options.Region = region
+					options.Region = bucketOptions.Region
+					if bucketOptions.CredentialsProvider != nil {
+						options.Credentials = bucketOptions.CredentialsProvider
+					}
 				})
 			})
 		if err != nil {
-			h.logger.Errorf("failed to generate presigned URL for bucket=%s key=%s: %v", row.S3Bucket, row.S3Key, err)
+			h.logger.Errorf("failed to generate presigned URL for bucket=%s key=%s: %v", s3Bucket, row.S3Key, err)
 			return nil, fmt.Errorf("failed to generate presigned URL: %w", err)
 		}
 

--- a/lambda/service/handler/download_test.go
+++ b/lambda/service/handler/download_test.go
@@ -3,8 +3,17 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
 	"net/http"
+	"net/url"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pennsieve/packages-service/api/models"
@@ -49,6 +58,7 @@ func viewerClaims(orgId int64, datasetNodeId string) *authorizer.Claims {
 }
 
 func setupDownloadTestDB(t *testing.T) *store.TestDB {
+	t.Helper()
 	db := store.OpenDB(t)
 	db.ExecSQLFile("download-manifest-test.sql")
 
@@ -66,6 +76,7 @@ func setupDownloadTestDB(t *testing.T) *store.TestDB {
 }
 
 func setupS3Client(t *testing.T) {
+	t.Helper()
 	awsConfig := store.GetTestAWSConfig(t)
 	originalS3 := S3Client
 	S3Client = s3.NewFromConfig(awsConfig)
@@ -73,9 +84,19 @@ func setupS3Client(t *testing.T) {
 }
 
 func setupExternalBucketConfig(t *testing.T, externalBucketConfig ExternalBucketConfig) {
+	t.Helper()
 	bytes, err := json.Marshal(externalBucketConfig)
 	require.NoError(t, err)
 	t.Setenv(ExternalBucketsRoleMapKey, string(bytes))
+}
+
+func setupAssumeRoleClient(t *testing.T, assumeRoleClient stscreds.AssumeRoleAPIClient) {
+	t.Helper()
+	originalAssumeRoleClient := AssumeRoleClient
+	AssumeRoleClient = assumeRoleClient
+	t.Cleanup(func() {
+		AssumeRoleClient = originalAssumeRoleClient
+	})
 }
 
 func TestDownloadManifest_SinglePackage(t *testing.T) {
@@ -178,7 +199,7 @@ func TestDownloadManifest_PublishedPackage(t *testing.T) {
 	setupExternalBucketConfig(t, nil)
 
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-published"}})
-	req := newTestRequest("POST", "/download-manifest", "test-req-4",
+	req := newTestRequest("POST", "/download-manifest", "test-req-40",
 		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
 	handler := NewHandler(req, editorClaims(2, "N:dataset:dl-test")).WithDefaultService()
 
@@ -202,6 +223,123 @@ func TestDownloadManifest_PublishedPackage(t *testing.T) {
 	assert.Contains(t, entry.URL, "versionId=Pu_BlishedVersionId")
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, entry.Path)
+}
+
+// TestDownloadManifest_NonUSPackage indirectly tests that we are setting the
+// region based on bucket name suffix by looking at a query param in the presigned URL.
+// Best option without a mockable S3 or presign client.
+func TestDownloadManifest_NonUSPackage(t *testing.T) {
+	setupDownloadTestDB(t)
+	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
+
+	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-non-us"}})
+	req := newTestRequest("POST", "/download-manifest", "test-req-40",
+		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
+	handler := NewHandler(req, editorClaims(2, "N:dataset:dl-test")).WithDefaultService()
+
+	resp, err := handler.handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var manifest models.DownloadManifestResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &manifest))
+
+	assert.Equal(t, 1, manifest.Header.Count)
+	assert.Equal(t, int64(8192), manifest.Header.Size)
+	require.Len(t, manifest.Data, 1)
+
+	entry := manifest.Data[0]
+	assert.Equal(t, "N:package:dl-non-us", entry.NodeId)
+	assert.Equal(t, "non-us-image.ome.tiff", entry.FileName)
+	assert.Equal(t, "non-us-file", entry.PackageName)
+	assert.Equal(t, "ome.tiff", entry.FileExtension)
+	assert.Contains(t, entry.URL, "pennsieve-test-storage-afs1")
+	u, err := url.Parse(entry.URL)
+	require.NoError(t, err)
+	credential := u.Query().Get("X-Amz-Credential")
+	assert.Contains(t, credential, "/af-south-1/s3/")
+	// Single-file package: path should be empty (no parents)
+	assert.Empty(t, entry.Path)
+}
+
+func TestDownloadManifest_ExternalPublishBucket(t *testing.T) {
+	setupDownloadTestDB(t)
+	setupS3Client(t)
+	// treat pennsieve-test-publish as an external bucket
+	bucketConfig := ExternalBucketConfig(map[string]string{"pennsieve-test-publish": "pennsieve-test-role-arn"})
+	setupExternalBucketConfig(t, bucketConfig)
+
+	expectedDuration := 180 * time.Minute
+	mockAssumeRoleClient := new(MockAssumeRoleClient)
+	mockAssumeRoleClient.On("AssumeRole", mock.Anything, mock.MatchedBy(func(input *sts.AssumeRoleInput) bool {
+		return assert.Equal(t, "pennsieve-test-role-arn", *input.RoleArn) &&
+			assert.Equal(t, "packages-service-presign-session", *input.RoleSessionName) &&
+			assert.Equal(t, int32(expectedDuration.Seconds()), *input.DurationSeconds) &&
+			assert.NotNil(t, input.Policy) &&
+			assert.Contains(t, *input.Policy, "s3:GetObject") &&
+			assert.Contains(t, *input.Policy, "s3:GetObjectVersion") &&
+			assert.NotContains(t, *input.Policy, "s3:PutObject")
+	}), mock.Anything).Return(&sts.AssumeRoleOutput{
+		AssumedRoleUser: &types.AssumedRoleUser{},
+		Credentials: &types.Credentials{
+			AccessKeyId:     aws.String(uuid.NewString()),
+			Expiration:      aws.Time(time.Now().Add(expectedDuration)),
+			SecretAccessKey: aws.String(uuid.NewString()),
+			SessionToken:    aws.String(uuid.NewString()),
+		},
+		PackedPolicySize: nil,
+		SourceIdentity:   nil,
+	}, nil)
+	setupAssumeRoleClient(t, mockAssumeRoleClient)
+
+	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-published", "N:package:dl-standalone"}})
+	req := newTestRequest("POST", "/download-manifest", "test-req-400",
+		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
+	handler := NewHandler(req, editorClaims(2, "N:dataset:dl-test")).WithDefaultService()
+
+	resp, err := handler.handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var manifest models.DownloadManifestResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &manifest))
+
+	// Assume role should only be called once since only one package with external bucket
+	mockAssumeRoleClient.AssertNumberOfCalls(t, "AssumeRole", 1)
+
+	assert.Equal(t, 2, manifest.Header.Count)
+	assert.Equal(t, int64(8192+8192), manifest.Header.Size)
+	require.Len(t, manifest.Data, 2)
+
+	publishedEntryIdx := slices.IndexFunc(manifest.Data, func(entry models.DownloadManifestEntry) bool {
+		return entry.NodeId == "N:package:dl-published"
+	})
+	require.True(t, publishedEntryIdx > -1)
+
+	publishedEntry := manifest.Data[publishedEntryIdx]
+	assert.Equal(t, "N:package:dl-published", publishedEntry.NodeId)
+	assert.Equal(t, "published-image.ome.tiff", publishedEntry.FileName)
+	assert.Equal(t, "published-file", publishedEntry.PackageName)
+	assert.Equal(t, "ome.tiff", publishedEntry.FileExtension)
+	assert.Contains(t, publishedEntry.URL, "pennsieve-test-publish")
+	assert.Contains(t, publishedEntry.URL, "versionId=Pu_BlishedVersionId")
+	// Single-file package: path should be empty (no parents)
+	assert.Empty(t, publishedEntry.Path)
+
+	standaloneEntryIdx := slices.IndexFunc(manifest.Data, func(entry models.DownloadManifestEntry) bool {
+		return entry.NodeId == "N:package:dl-standalone"
+	})
+	require.True(t, standaloneEntryIdx > -1)
+	standaloneEntry := manifest.Data[standaloneEntryIdx]
+	assert.Equal(t, "N:package:dl-standalone", standaloneEntry.NodeId)
+	assert.Equal(t, "image.ome.tiff", standaloneEntry.FileName)
+	assert.Equal(t, "standalone-file", standaloneEntry.PackageName)
+	assert.Equal(t, "ome.tiff", standaloneEntry.FileExtension)
+	assert.Contains(t, standaloneEntry.URL, "pennsieve-test-storage")
+	// Single-file package: path should be empty (no parents)
+	assert.Empty(t, standaloneEntry.Path)
+
 }
 
 func TestDownloadManifest_EmptyNodeIds(t *testing.T) {
@@ -293,4 +431,13 @@ func TestGetFullExtension(t *testing.T) {
 			assert.Equal(t, tt.expected, getFullExtension(tt.input))
 		})
 	}
+}
+
+type MockAssumeRoleClient struct {
+	mock.Mock
+}
+
+func (m *MockAssumeRoleClient) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*sts.AssumeRoleOutput), args.Error(1)
 }

--- a/lambda/service/handler/download_test.go
+++ b/lambda/service/handler/download_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,7 +126,13 @@ func TestDownloadManifest_SinglePackage(t *testing.T) {
 	assert.Equal(t, "image.ome.tiff", entry.FileName)
 	assert.Equal(t, "standalone-file", entry.PackageName)
 	assert.Equal(t, "ome.tiff", entry.FileExtension)
-	assert.Contains(t, entry.URL, "pennsieve-test-storage")
+	presignedURL, err := url.Parse(entry.URL)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(presignedURL.Host, "pennsieve-test-storage"))
+	assert.Equal(t, "/org2/image.ome.tiff", presignedURL.Path)
+	assert.Empty(t, presignedURL.Query().Get("versionId"))
+	assert.Empty(t, presignedURL.Query().Get("x-amz-request-payer"))
+	assert.Contains(t, presignedURL.Query().Get("X-Amz-Credential"), "/us-east-1/s3/")
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, entry.Path)
 }
@@ -219,8 +226,13 @@ func TestDownloadManifest_PublishedPackage(t *testing.T) {
 	assert.Equal(t, "published-image.ome.tiff", entry.FileName)
 	assert.Equal(t, "published-file", entry.PackageName)
 	assert.Equal(t, "ome.tiff", entry.FileExtension)
-	assert.Contains(t, entry.URL, "pennsieve-test-publish")
-	assert.Contains(t, entry.URL, "versionId=Pu_BlishedVersionId")
+	presignedURL, err := url.Parse(entry.URL)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(presignedURL.Host, "pennsieve-test-publish"))
+	assert.Equal(t, "/14/files/published-image.ome.tiff", presignedURL.Path)
+	assert.Equal(t, "Pu_BlishedVersionId", presignedURL.Query().Get("versionId"))
+	assert.Empty(t, presignedURL.Query().Get("x-amz-request-payer"))
+	assert.Contains(t, presignedURL.Query().Get("X-Amz-Credential"), "/us-east-1/s3/")
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, entry.Path)
 }
@@ -254,11 +266,13 @@ func TestDownloadManifest_NonUSPackage(t *testing.T) {
 	assert.Equal(t, "non-us-image.ome.tiff", entry.FileName)
 	assert.Equal(t, "non-us-file", entry.PackageName)
 	assert.Equal(t, "ome.tiff", entry.FileExtension)
-	assert.Contains(t, entry.URL, "pennsieve-test-storage-afs1")
 	u, err := url.Parse(entry.URL)
 	require.NoError(t, err)
-	credential := u.Query().Get("X-Amz-Credential")
-	assert.Contains(t, credential, "/af-south-1/s3/")
+	assert.True(t, strings.HasPrefix(u.Host, "pennsieve-test-storage-afs1"))
+	assert.Contains(t, u.Query().Get("X-Amz-Credential"), "/af-south-1/s3/")
+	assert.Equal(t, "/15/files/non-us-image.ome.tiff", u.Path)
+	assert.Empty(t, u.Query().Get("versionId"))
+	assert.Empty(t, u.Query().Get("x-amz-request-payer"))
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, entry.Path)
 }
@@ -322,8 +336,13 @@ func TestDownloadManifest_ExternalPublishBucket(t *testing.T) {
 	assert.Equal(t, "published-image.ome.tiff", publishedEntry.FileName)
 	assert.Equal(t, "published-file", publishedEntry.PackageName)
 	assert.Equal(t, "ome.tiff", publishedEntry.FileExtension)
-	assert.Contains(t, publishedEntry.URL, "pennsieve-test-publish")
-	assert.Contains(t, publishedEntry.URL, "versionId=Pu_BlishedVersionId")
+	publishedURL, err := url.Parse(publishedEntry.URL)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(publishedURL.Host, "pennsieve-test-publish"))
+	assert.Equal(t, "/14/files/published-image.ome.tiff", publishedURL.Path)
+	assert.Equal(t, "Pu_BlishedVersionId", publishedURL.Query().Get("versionId"))
+	assert.Equal(t, "requester", publishedURL.Query().Get("x-amz-request-payer"))
+	assert.Contains(t, publishedURL.Query().Get("X-Amz-Credential"), "/us-east-1/s3/")
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, publishedEntry.Path)
 
@@ -336,7 +355,13 @@ func TestDownloadManifest_ExternalPublishBucket(t *testing.T) {
 	assert.Equal(t, "image.ome.tiff", standaloneEntry.FileName)
 	assert.Equal(t, "standalone-file", standaloneEntry.PackageName)
 	assert.Equal(t, "ome.tiff", standaloneEntry.FileExtension)
-	assert.Contains(t, standaloneEntry.URL, "pennsieve-test-storage")
+	standaloneURL, err := url.Parse(standaloneEntry.URL)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(standaloneURL.Host, "pennsieve-test-storage"))
+	assert.Equal(t, "/org2/image.ome.tiff", standaloneURL.Path)
+	assert.Empty(t, standaloneURL.Query().Get("versionId"))
+	assert.Empty(t, standaloneURL.Query().Get("x-amz-request-payer"))
+	assert.Contains(t, standaloneURL.Query().Get("X-Amz-Credential"), "/us-east-1/s3/")
 	// Single-file package: path should be empty (no parents)
 	assert.Empty(t, standaloneEntry.Path)
 

--- a/lambda/service/handler/download_test.go
+++ b/lambda/service/handler/download_test.go
@@ -163,6 +163,37 @@ func TestDownloadManifest_DeletedPackagesExcluded(t *testing.T) {
 	assert.Equal(t, "N:package:dl-standalone", manifest.Data[0].NodeId)
 }
 
+func TestDownloadManifest_PublishedPackage(t *testing.T) {
+	setupDownloadTestDB(t)
+	setupS3Client(t)
+
+	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-published"}})
+	req := newTestRequest("POST", "/download-manifest", "test-req-4",
+		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
+	handler := NewHandler(req, editorClaims(2, "N:dataset:dl-test")).WithDefaultService()
+
+	resp, err := handler.handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var manifest models.DownloadManifestResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &manifest))
+
+	assert.Equal(t, 1, manifest.Header.Count)
+	assert.Equal(t, int64(8192), manifest.Header.Size)
+	require.Len(t, manifest.Data, 1)
+
+	entry := manifest.Data[0]
+	assert.Equal(t, "N:package:dl-published", entry.NodeId)
+	assert.Equal(t, "published-image.ome.tiff", entry.FileName)
+	assert.Equal(t, "published-file", entry.PackageName)
+	assert.Equal(t, "ome.tiff", entry.FileExtension)
+	assert.Contains(t, entry.URL, "pennsieve-test-publish")
+	assert.Contains(t, entry.URL, "versionId=Pu_BlishedVersionId")
+	// Single-file package: path should be empty (no parents)
+	assert.Empty(t, entry.Path)
+}
+
 func TestDownloadManifest_EmptyNodeIds(t *testing.T) {
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-4",

--- a/lambda/service/handler/download_test.go
+++ b/lambda/service/handler/download_test.go
@@ -72,9 +72,16 @@ func setupS3Client(t *testing.T) {
 	t.Cleanup(func() { S3Client = originalS3 })
 }
 
+func setupExternalBucketConfig(t *testing.T, externalBucketConfig ExternalBucketConfig) {
+	bytes, err := json.Marshal(externalBucketConfig)
+	require.NoError(t, err)
+	t.Setenv(ExternalBucketsRoleMapKey, string(bytes))
+}
+
 func TestDownloadManifest_SinglePackage(t *testing.T) {
 	setupDownloadTestDB(t)
 	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
 
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-standalone"}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-1",
@@ -105,6 +112,7 @@ func TestDownloadManifest_SinglePackage(t *testing.T) {
 func TestDownloadManifest_Collection(t *testing.T) {
 	setupDownloadTestDB(t)
 	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
 
 	// Request the collection — should return all child files (not the collection itself)
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:collection:dl-root"}})
@@ -144,6 +152,7 @@ func TestDownloadManifest_Collection(t *testing.T) {
 func TestDownloadManifest_DeletedPackagesExcluded(t *testing.T) {
 	setupDownloadTestDB(t)
 	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
 
 	// Request both a valid and a deleted package
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-standalone", "N:package:dl-deleted"}})
@@ -166,6 +175,7 @@ func TestDownloadManifest_DeletedPackagesExcluded(t *testing.T) {
 func TestDownloadManifest_PublishedPackage(t *testing.T) {
 	setupDownloadTestDB(t)
 	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
 
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-published"}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-4",
@@ -195,6 +205,7 @@ func TestDownloadManifest_PublishedPackage(t *testing.T) {
 }
 
 func TestDownloadManifest_EmptyNodeIds(t *testing.T) {
+	setupExternalBucketConfig(t, nil)
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-4",
 		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
@@ -206,6 +217,8 @@ func TestDownloadManifest_EmptyNodeIds(t *testing.T) {
 }
 
 func TestDownloadManifest_MissingDatasetId(t *testing.T) {
+	setupExternalBucketConfig(t, nil)
+
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-standalone"}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-5",
 		map[string]string{}, string(body))
@@ -217,6 +230,8 @@ func TestDownloadManifest_MissingDatasetId(t *testing.T) {
 }
 
 func TestDownloadManifest_Unauthorized(t *testing.T) {
+	setupExternalBucketConfig(t, nil)
+
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:dl-standalone"}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-6",
 		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
@@ -241,6 +256,7 @@ func TestDownloadManifest_Unauthorized(t *testing.T) {
 func TestDownloadManifest_NonexistentPackage(t *testing.T) {
 	setupDownloadTestDB(t)
 	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
 
 	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{"N:package:does-not-exist"}})
 	req := newTestRequest("POST", "/download-manifest", "test-req-7",

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/packages-service/api/logging"
 	"github.com/pennsieve/packages-service/api/service"
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
@@ -20,7 +20,7 @@ import (
 var PennsieveDB *sql.DB
 var SQSClient *sqs.Client
 var S3Client *s3.Client
-var STSClient *sts.Client
+var AssumeRoleClient stscreds.AssumeRoleAPIClient
 var ViewerAssetsBucket string
 
 func init() {

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/packages-service/api/logging"
 	"github.com/pennsieve/packages-service/api/service"
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
@@ -19,6 +20,7 @@ import (
 var PennsieveDB *sql.DB
 var SQSClient *sqs.Client
 var S3Client *s3.Client
+var STSClient *sts.Client
 var ViewerAssetsBucket string
 
 func init() {

--- a/lambda/service/handler/testdata/download-manifest-test.sql
+++ b/lambda/service/handler/testdata/download-manifest-test.sql
@@ -12,7 +12,8 @@ ON CONFLICT (id) DO NOTHING;
 --   └── child-multi-file  (CSV, id=3002, 2 source files)
 -- standalone-file (Text, id=3003, 1 source file)
 -- deleted-file (Text, id=3004, DELETED, 1 source file — should NOT appear)
--- published-file (Text, id-3005, 1 published source file, so need to use S3 versionId when creating presigned URL)
+-- published-file (Text, id=3005, 1 published source file, so need to use S3 versionId when creating presigned URL)
+-- non-us-file (Text, id=3006, 1 source file in a non us-east-1 bucket
 
 INSERT INTO "2".packages (id, name, type, state, dataset_id, parent_id, updated_at, created_at, attributes, node_id, size, owner_id, import_id) VALUES
 (3000, 'root-collection', 'Collection', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:collection:dl-root', null, 1, '00000000-0000-0000-0000-000000003000'),
@@ -20,7 +21,8 @@ INSERT INTO "2".packages (id, name, type, state, dataset_id, parent_id, updated_
 (3002, 'child-multi-file', 'CSV', 'READY', 300, 3000, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-child-multi', null, 1, '00000000-0000-0000-0000-000000003002'),
 (3003, 'standalone-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-standalone', null, 1, '00000000-0000-0000-0000-000000003003'),
 (3004, 'deleted-file', 'Text', 'DELETED', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-deleted', null, 1, '00000000-0000-0000-0000-000000003004'),
-(3005, 'published-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-published', null, 1, '00000000-0000-0000-0000-000000003005')
+(3005, 'published-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-published', null, 1, '00000000-0000-0000-0000-000000003005'),
+(3006, 'non-us-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-non-us', null, 1, '00000000-0000-0000-0000-000000003006')
 ON CONFLICT (id) DO NOTHING;
 
 -- Files: object_type = 'source' for downloadable files
@@ -48,4 +50,9 @@ ON CONFLICT (id) DO NOTHING;
 -- published-file has 1 source file (with non-null versionId for publishedd file test)
 INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, published_s3_version_id, object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES
     (5006, 3005, 'published-image.ome.tiff', 'OMETIFF', 'pennsieve-test-publish', '14/files/published-image.ome.tiff', 'Pu_BlishedVersionId','source', 8192, '{}', '00000000-0000-0000-0000-000000005006', 'unprocessed', 'uploaded', '2023-01-01 00:00:00', '2023-01-01 00:00:00')
+ON CONFLICT (id) DO NOTHING;
+
+-- nob-us-file has 1 source file in a bucket not in us-east-1
+INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES
+    (5007, 3006, 'non-us-image.ome.tiff', 'OMETIFF', 'pennsieve-test-storage-afs1', '15/files/non-us-image.ome.tiff','source', 8192, '{}', '00000000-0000-0000-0000-000000005007', 'unprocessed', 'uploaded', '2023-01-01 00:00:00', '2023-01-01 00:00:00')
 ON CONFLICT (id) DO NOTHING;

--- a/lambda/service/handler/testdata/download-manifest-test.sql
+++ b/lambda/service/handler/testdata/download-manifest-test.sql
@@ -12,13 +12,15 @@ ON CONFLICT (id) DO NOTHING;
 --   └── child-multi-file  (CSV, id=3002, 2 source files)
 -- standalone-file (Text, id=3003, 1 source file)
 -- deleted-file (Text, id=3004, DELETED, 1 source file — should NOT appear)
+-- published-file (Text, id-3005, 1 published source file, so need to use S3 versionId when creating presigned URL)
 
 INSERT INTO "2".packages (id, name, type, state, dataset_id, parent_id, updated_at, created_at, attributes, node_id, size, owner_id, import_id) VALUES
 (3000, 'root-collection', 'Collection', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:collection:dl-root', null, 1, '00000000-0000-0000-0000-000000003000'),
 (3001, 'child-single-file', 'CSV', 'READY', 300, 3000, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-child-single', null, 1, '00000000-0000-0000-0000-000000003001'),
 (3002, 'child-multi-file', 'CSV', 'READY', 300, 3000, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-child-multi', null, 1, '00000000-0000-0000-0000-000000003002'),
 (3003, 'standalone-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-standalone', null, 1, '00000000-0000-0000-0000-000000003003'),
-(3004, 'deleted-file', 'Text', 'DELETED', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-deleted', null, 1, '00000000-0000-0000-0000-000000003004')
+(3004, 'deleted-file', 'Text', 'DELETED', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-deleted', null, 1, '00000000-0000-0000-0000-000000003004'),
+(3005, 'published-file', 'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-published', null, 1, '00000000-0000-0000-0000-000000003005')
 ON CONFLICT (id) DO NOTHING;
 
 -- Files: object_type = 'source' for downloadable files
@@ -41,4 +43,9 @@ ON CONFLICT (id) DO NOTHING;
 -- deleted-file has 1 source file (should not be returned because package is DELETED)
 INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES
 (5005, 3004, 'gone.txt', 'Text', 'pennsieve-test-storage', 'org2/gone.txt', 'source', 100, '{}', '00000000-0000-0000-0000-000000005005', 'unprocessed', 'uploaded', '2023-01-01 00:00:00', '2023-01-01 00:00:00')
+ON CONFLICT (id) DO NOTHING;
+
+-- published-file has 1 source file (with non-null versionId for publishedd file test)
+INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, published_s3_version_id, object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES
+    (5006, 3005, 'published-image.ome.tiff', 'OMETIFF', 'pennsieve-test-publish', '14/files/published-image.ome.tiff', 'Pu_BlishedVersionId','source', 8192, '{}', '00000000-0000-0000-0000-000000005006', 'unprocessed', 'uploaded', '2023-01-01 00:00:00', '2023-01-01 00:00:00')
 ON CONFLICT (id) DO NOTHING;

--- a/lambda/service/main.go
+++ b/lambda/service/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pennsieve/packages-service/service/handler"
 	"github.com/pennsieve/pennsieve-go-core/pkg/queries/pgdb"
 	log "github.com/sirupsen/logrus"
@@ -34,6 +35,7 @@ func init() {
 
 	handler.SQSClient = sqs.NewFromConfig(cfg)
 	handler.S3Client = s3.NewFromConfig(cfg)
+	handler.STSClient = sts.NewFromConfig(cfg)
 }
 
 func main() {

--- a/lambda/service/main.go
+++ b/lambda/service/main.go
@@ -35,7 +35,7 @@ func init() {
 
 	handler.SQSClient = sqs.NewFromConfig(cfg)
 	handler.S3Client = s3.NewFromConfig(cfg)
-	handler.STSClient = sts.NewFromConfig(cfg)
+	handler.AssumeRoleClient = sts.NewFromConfig(cfg)
 }
 
 func main() {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -102,6 +102,10 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
       data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,
       "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn}/*",
       data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
       "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       "arn:aws:s3:::pennsieve-*-package-*/*"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -115,7 +115,6 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   # Allow assuming cross-account roles for external publish buckets
   # - sparc_bucket_role_arn: SPARC account buckets
   # - rejoin_bucket_role_arn: RE-JOIN and PRECISION account buckets (same account)
-  # - awsod_sparc_bucket_role_arn: AWS Open Data account buckets (SPARC AOD and Epilepsy.science)
   statement {
     sid    = "AssumeExternalPublishBucketRoles"
     effect = "Allow"
@@ -123,7 +122,6 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn,
       data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn,
-      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn,
     ]
   }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
-      "s3:HeadObject"
+      "s3:GetObjectVersion"
     ]
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn,

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -36,8 +36,8 @@ resource "aws_iam_policy" "packages_service_lambda_iam_policy" {
 data "aws_iam_policy_document" "packages_service_iam_policy_document" {
 
   statement {
-    sid     = "PackagesServiceLambdaLogsPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaLogsPermissions"
+    effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
@@ -49,8 +49,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaEC2Permissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaEC2Permissions"
+    effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DescribeNetworkInterfaces",
@@ -62,8 +62,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaRDSPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaRDSPermissions"
+    effect = "Allow"
     actions = [
       "rds-db:connect"
     ]
@@ -85,21 +85,47 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaS3Permissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaS3Permissions"
+    effect = "Allow"
     actions = [
       "s3:GetObject",
       "s3:HeadObject"
     ]
     resources = [
-      "arn:aws:s3:::pennsieve-*-storage-*/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
+      data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn,
+      "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_storage_bucket_arn}/*",
+      data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service.outputs.uploads_bucket_arn}/*",
       "arn:aws:s3:::pennsieve-*-package-*/*"
     ]
   }
 
+  # Allow assuming cross-account roles for external publish buckets
+  # - sparc_bucket_role_arn: SPARC account buckets
+  # - rejoin_bucket_role_arn: RE-JOIN and PRECISION account buckets (same account)
+  # - awsod_sparc_bucket_role_arn: AWS Open Data account buckets (SPARC AOD and Epilepsy.science)
   statement {
-    sid     = "PackagesServiceLambdaSSMPermissions"
-    effect  = "Allow"
+    sid    = "AssumeExternalPublishBucketRoles"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn,
+    ]
+  }
+
+  statement {
+    sid    = "PackagesServiceLambdaSSMPermissions"
+    effect = "Allow"
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
@@ -111,8 +137,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaSecretsManagerPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaSecretsManagerPermissions"
+    effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
@@ -123,8 +149,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid     = "PackagesServiceLambdaKMSDecryptPermissions"
-    effect  = "Allow"
+    sid    = "PackagesServiceLambdaKMSDecryptPermissions"
+    effect = "Allow"
     actions = [
       "kms:Decrypt"
     ]
@@ -174,8 +200,8 @@ resource "aws_iam_policy" "restore_package_lambda_iam_policy" {
 data "aws_iam_policy_document" "restore_package_iam_policy_document" {
 
   statement {
-    sid     = "RestorePackageLambdaLogsPermissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaLogsPermissions"
+    effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
@@ -187,8 +213,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
   }
 
   statement {
-    sid     = "RestorePackageLambdaEC2Permissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaEC2Permissions"
+    effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DescribeNetworkInterfaces",
@@ -200,8 +226,8 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
   }
 
   statement {
-    sid     = "RestorePackageLambdaRDSPermissions"
-    effect  = "Allow"
+    sid    = "RestorePackageLambdaRDSPermissions"
+    effect = "Allow"
     actions = [
       "rds-db:connect"
     ]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "service_lambda" {
       CLOUDFRONT_KEY_ID                   = data.terraform_remote_state.platform_infrastructure.outputs.assets_distribution_public_key
       CLOUDFRONT_KEY_GROUP_ID             = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
       CLOUDFRONT_SIGNING_KEYS_SECRET_NAME = aws_secretsmanager_secret.cloudfront_signing_keys.name
-      EXTERNAL_BUCKETS_ROLE_MAP = jsondecode(local.external_bucket_roles)
+      EXTERNAL_BUCKETS_ROLE_MAP = jsonencode(local.external_bucket_roles)
     }
   }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "service_lambda" {
   s3_key        = "${var.service_name}/packages-service-${var.image_tag}.zip"
 
   vpc_config {
-    subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+    subnet_ids = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
     security_group_ids = [data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_security_group_id]
   }
 
@@ -25,6 +25,7 @@ resource "aws_lambda_function" "service_lambda" {
       CLOUDFRONT_KEY_ID                   = data.terraform_remote_state.platform_infrastructure.outputs.assets_distribution_public_key
       CLOUDFRONT_KEY_GROUP_ID             = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
       CLOUDFRONT_SIGNING_KEYS_SECRET_NAME = aws_secretsmanager_secret.cloudfront_signing_keys.name
+      EXTERNAL_BUCKETS_ROLE_MAP = jsondecode(local.external_bucket_roles)
     }
   }
 }
@@ -41,7 +42,7 @@ resource "aws_lambda_function" "restore_package_lambda" {
   s3_key        = "${var.service_name}/restore-package-${var.image_tag}.zip"
 
   vpc_config {
-    subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+    subnet_ids = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
     security_group_ids = [data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_security_group_id]
   }
 
@@ -72,8 +73,8 @@ resource "aws_lambda_function" "key_rotation" {
 
   environment {
     variables = {
-      ENVIRONMENT                    = var.environment_name
-      CLOUDFRONT_KEY_GROUP_ID        = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
+      ENVIRONMENT                     = var.environment_name
+      CLOUDFRONT_KEY_GROUP_ID         = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
       KEY_ROTATION_GRACE_PERIOD_HOURS = "48"  # Grace period before removing old keys from CloudFront
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,13 +53,9 @@ locals {
   external_bucket_roles = {
     // NIH account SPARC publish bucket to role
     (data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn
-    // AOD account SPARC publish bucket to role
-    (data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn
     // REJOIN account RE-JOIN publish bucket to role
     (data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
     // REJOIN account PRECISION publish bucket to role (same as RE-JOIN bucket's role)
     (data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
-    // AOD account Epilepsy.Science publish bucket to role. (TODO is this role correct)
-    (data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,5 +48,18 @@ locals {
     aws_region       = data.aws_region.current_region.name
     environment_name = var.environment_name
   }
-  cors_allowed_origins  = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
+  cors_allowed_origins = (var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"]
+    : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"])
+  external_bucket_roles = {
+    // NIH account SPARC publish bucket to role
+    (data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn
+    // AOD account SPARC publish bucket to role
+    (data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn
+    // REJOIN account RE-JOIN publish bucket to role
+    (data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
+    // REJOIN account PRECISION publish bucket to role (same as RE-JOIN bucket's role)
+    (data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
+    // AOD account Epilepsy.Science publish bucket to role. (TODO is this role correct)
+    (data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_id) = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn
+  }
 }


### PR DESCRIPTION
Updates the restore and download-manifest handlers to take a bucket's region into account as determined by the short region name suffix.

Updates the download-manifest handler to also use the file's S3 versionId when present. 

Fixes the IAM policy so that the download-manifest handler will have access to the buckets that may now hold files. 

And updates the URL presigning in the download-manifest handler to assume the correct external role for external buckets that have requester pays enabled.

non-prod Terraform plan:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.packages_service.aws_cloudwatch_event_target.cloudfront_key_cleanup_target will be updated in-place
  ~ resource "aws_cloudwatch_event_target" "cloudfront_key_cleanup_target" {
        id             = "dev-packages-service-cloudfront-key-cleanup-CloudFrontKeyCleanupTarget"
      ~ input          = jsonencode(
            {
              - ClientRequestToken = "scheduled-cleanup-2026-03-18-2036"
              - SecretId           = "arn:aws:secretsmanager:us-east-1:941165240011:secret:dev-packages-service-cloudfront-signing-keys-HLr9RM"
              - Step               = "cleanupOldKeys"
            }
        ) -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # module.packages_service.aws_iam_policy.packages_service_lambda_iam_policy will be updated in-place
  ~ resource "aws_iam_policy" "packages_service_lambda_iam_policy" {
        id               = "arn:aws:iam::941165240011:policy/dev-packages-service-lambda-iam-policy-use1"
        name             = "dev-packages-service-lambda-iam-policy-use1"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                    # (3 unchanged elements hidden)
                    {
                        Action   = [
                            "sqs:SendMessage",
                            "sqs:GetQueueUrl",
                        ]
                        Effect   = "Allow"
                        Resource = "arn:aws:sqs:us-east-1:941165240011:dev-restore-package-queue-use1"
                        Sid      = "PackageServiceLambdaWriteToEventsPermission"
                    },
                  ~ {
                      ~ Action   = [
                          - "s3:HeadObject",
                          + "s3:GetObjectVersion",
                            "s3:GetObject",
                        ]
                      ~ Resource = [
                          - "arn:aws:s3:::pennsieve-*-storage-*/*",
                          + "arn:aws:s3:::sparc-dev-aod-discover-publish50-use1/*",
                          + "arn:aws:s3:::sparc-dev-aod-discover-publish50-use1",
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1/*",
                          + "arn:aws:s3:::pennsieve-dev-uploads-v2-use1",
                          + "arn:aws:s3:::pennsieve-dev-storage-use1/*",
                          + "arn:aws:s3:::pennsieve-dev-storage-use1",
                          + "arn:aws:s3:::pennsieve-dev-storage-afs1/*",
                          + "arn:aws:s3:::pennsieve-dev-storage-afs1",
                            "arn:aws:s3:::pennsieve-*-package-*/*",
                          + "arn:aws:s3:::edots-dev-aod-discover-publish50-use1/*",
                          + "arn:aws:s3:::edots-dev-aod-discover-publish50-use1",
                          + "arn:aws:s3:::dev-sparc-storage-use1/*",
                          + "arn:aws:s3:::dev-sparc-storage-use1",
                          + "arn:aws:s3:::dev-rejoin-storage-use1/*",
                          + "arn:aws:s3:::dev-rejoin-storage-use1",
                          + "arn:aws:s3:::dev-precision-storage-use1/*",
                          + "arn:aws:s3:::dev-precision-storage-use1",
                        ]
                        # (2 unchanged elements hidden)
                    },
                  + {
                      + Action   = "sts:AssumeRole"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:iam::376308453966:role/dev-publish-buckets-access-role-use1",
                          + "arn:aws:iam::225366564863:role/dev-publish-buckets-access-role-use1",
                        ]
                      + Sid      = "AssumeExternalPublishBucketRoles"
                    },
                    {
                        Action   = [
                            "ssm:GetParametersByPath",
                            "ssm:GetParameters",
                            "ssm:GetParameter",
                        ]
                        Effect   = "Allow"
                        Resource = "arn:aws:ssm:us-east-1:941165240011:parameter/dev/packages-service/*"
                        Sid      = "PackagesServiceLambdaSSMPermissions"
                    },
                    # (2 unchanged elements hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        tags             = {}
        # (5 unchanged attributes hidden)
    }

  # module.packages_service.aws_lambda_function.service_lambda will be updated in-place
  ~ resource "aws_lambda_function" "service_lambda" {
        id                             = "dev-packages-service-lambda-use1"
        tags                           = {}
        # (27 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              + "EXTERNAL_BUCKETS_ROLE_MAP"           = jsonencode(
                    {
                      + dev-precision-discover50-use1 = "arn:aws:iam::225366564863:role/dev-publish-buckets-access-role-use1"
                      + dev-rejoin-discover50-use1    = "arn:aws:iam::225366564863:role/dev-publish-buckets-access-role-use1"
                      + sparc-dev-discover50-use1     = "arn:aws:iam::376308453966:role/dev-publish-buckets-access-role-use1"
                    }
                )
                # (9 unchanged elements hidden)
            }
        }




        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```