### PR TITLE
Add dynamic storage node IAM policies

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -107,3 +107,15 @@ data "terraform_remote_state" "africa_south_region" {
     region = "us-east-1"
   }
 }
+
+# Import Account Service (storage node policies)
+data "terraform_remote_state" "account_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/account-service/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -324,3 +324,13 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
 
 }
 
+
+resource "aws_iam_role_policy_attachment" "storage_bucket_read" {
+  role       = aws_iam_role.packages_service_lambda_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_read_policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "restore_storage_bucket_write" {
+  role       = aws_iam_role.restore_package_lambda_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_write_policy_arn
+}


### PR DESCRIPTION
## Summary
- Import account-service terraform remote state
- Attach managed `storage_bucket_read` policy to `packages_service_lambda_role` (presigned GetObject URLs)
- Attach managed `storage_bucket_write` policy to `restore_package_lambda_role` (delete marker removal)

## Context
Part of the distributed storage nodes feature. The account-service maintains dynamically-updated IAM policies that are auto-updated when storage nodes are created/modified/deleted.

## Test plan
- [ ] Terraform plan shows only new policy attachment resources
- [ ] No changes to existing IAM policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)