### PR TITLE
Reduce restore latency and fix savepoint error masking

### DIFF
--- a/api/store/postgres.go
+++ b/api/store/postgres.go
@@ -18,9 +18,7 @@ import (
 )
 
 const (
-	uniqueViolationCode       = "23505"
-	rootPackageNameConstraint = "packages_name_dataset_id__parent_id_null_idx"
-	packageNameConstraint     = "packages_name_dataset_id_parent_id__parent_id_not_null_idx"
+	uniqueViolationCode = "23505"
 )
 
 var (
@@ -95,12 +93,13 @@ func (q *Queries) UpdatePackageName(ctx context.Context, packageId int64, newNam
 	query := fmt.Sprintf(`UPDATE "%d".packages SET name = $1 WHERE id = $2`, q.OrgId)
 	res, err := q.db.ExecContext(ctx, query, newName, packageId)
 	if err != nil {
-		if err, ok := err.(*pq.Error); ok && err.Code == uniqueViolationCode && (err.Constraint == rootPackageNameConstraint || err.Constraint == packageNameConstraint) {
+		// Any 23505 here is a name uniqueness collision — `name` is the only column touched.
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == uniqueViolationCode {
 			return models.PackageNameUniquenessError{
 				OrgId:    q.OrgId,
 				Id:       models.PackageIntId(packageId),
 				Name:     newName,
-				SQLError: err,
+				SQLError: pqErr,
 			}
 		}
 		return err

--- a/lambda/restore/handler/file.go
+++ b/lambda/restore/handler/file.go
@@ -27,6 +27,7 @@ var savepointReplacer = strings.NewReplacer(":", "", "-", "")
 
 func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datasetId int64, restoreInfo models.RestorePackageInfo) ([]changelog.PackageRestoreEvent, error) {
 	var changelogEvents []changelog.PackageRestoreEvent
+	var restoredSize int64
 	err := h.Store.SQLFactory.ExecStoreTx(ctx, orgId, func(sqlStore store.SQLStore) error {
 		// mark any deleted ancestors as restoring
 		var ancestors []models.RestorePackageInfo
@@ -95,13 +96,9 @@ func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datas
 			sqlStore.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "error": err}, "error removing delete record")
 		}
 
-		// restore dataset storage
-		restoredSize := sourceFileSize(sourceFiles)
+		// capture size for post-commit storage update
+		restoredSize = sourceFileSize(sourceFiles)
 		sqlStore.LogInfo("restored size: ", restoredSize)
-		if err = h.restoreStorage(ctx, int64(orgId), datasetId, restoreInfo, restoredSize, sqlStore); err != nil {
-			// Don't think this should fail the whole restore
-			sqlStore.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "error": err}, "could not update storage")
-		}
 
 		// restore states
 		stateRestores := make([]*models.RestorePackageInfo, len(ancestors)+1)
@@ -114,7 +111,21 @@ func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datas
 		}
 		return nil
 	})
-	return changelogEvents, err
+	if err != nil {
+		return changelogEvents, err
+	}
+
+	// Storage counters are updated outside the main tx so that row locks on the hot
+	// organization_storage and dataset_storage rows are held only for the UPSERTs
+	// themselves, not across S3/DynamoDB calls. Failures are logged but don't fail
+	// the restore — consistent with prior best-effort semantics.
+	simpleStore := h.Store.SQLFactory.NewSimpleStore(orgId)
+	if storageErr := h.restoreStorage(ctx, int64(orgId), datasetId, restoreInfo, restoredSize, simpleStore); storageErr != nil {
+		h.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "error": storageErr}, "could not update storage after restore")
+	}
+
+	h.LogInfoWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "size": restoredSize}, "restore complete")
+	return changelogEvents, nil
 }
 
 func (h *MessageHandler) restoreName(ctx context.Context, restoreInfo models.RestorePackageInfo, store store.SQLStore) (*RestoredName, error) {
@@ -138,11 +149,15 @@ func (h *MessageHandler) restoreName(ctx context.Context, restoreInfo models.Res
 		err = store.UpdatePackageName(ctx, restoreInfo.Id, newName)
 		h.LogDebugWithFields(log.Fields{"error": err, "newName": newName}, "retried name update")
 	}
+	if retryCtx.Err != nil {
+		// The last UPDATE failed and the tx is aborted. Rollback so callers can
+		// still see the real error instead of "current transaction is aborted".
+		// Skip ReleaseSavepoint — it would fail on an aborted tx and mask the root cause.
+		_ = store.RollbackToSavepoint(ctx, savepoint)
+		return nil, retryCtx.Err
+	}
 	if err = store.ReleaseSavepoint(ctx, savepoint); err != nil {
 		return nil, err
-	}
-	if retryCtx.Err != nil {
-		return nil, retryCtx.Err
 	}
 	restoredName := RestoredName{Value: newName}
 	if newName != originalName {

--- a/lambda/restore/handler/folder.go
+++ b/lambda/restore/handler/folder.go
@@ -14,6 +14,7 @@ import (
 
 func (h *MessageHandler) handleFolderPackage(ctx context.Context, orgId int, datasetId int64, restoreInfo models.RestorePackageInfo) ([]changelog.PackageRestoreEvent, error) {
 	var changelogEvents []changelog.PackageRestoreEvent
+	var restoredFileInfosOut RestoreFileInfos
 	err := h.Store.SQLFactory.ExecStoreTx(ctx, orgId, func(sqlStore store.SQLStore) error {
 		// gather ancestors and set to RESTORING
 		var ancestors []models.RestorePackageInfo
@@ -133,10 +134,8 @@ func (h *MessageHandler) handleFolderPackage(ctx context.Context, orgId int, dat
 			}
 		}
 
-		// restore dataset_storage
-		if err = h.restoreStorages(ctx, int64(orgId), datasetId, restoredFileInfos, sqlStore); err != nil {
-			sqlStore.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId}, "error updating storage", err)
-		}
+		// capture for post-commit storage update
+		restoredFileInfosOut = restoredFileInfos
 		// restore states
 		stateRestores := make([]*models.RestorePackageInfo, len(ancestors)+len(folderDescRestoreInfos)+len(restoredFileInfos)+1)
 		// add self
@@ -161,5 +160,16 @@ func (h *MessageHandler) handleFolderPackage(ctx context.Context, orgId int, dat
 		}
 		return nil
 	})
-	return changelogEvents, err
+	if err != nil {
+		return changelogEvents, err
+	}
+
+	// Storage counters run outside the main tx — see handleFilePackage for rationale.
+	simpleStore := h.Store.SQLFactory.NewSimpleStore(orgId)
+	if storageErr := h.restoreStorages(ctx, int64(orgId), datasetId, restoredFileInfosOut, simpleStore); storageErr != nil {
+		h.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "error": storageErr}, "could not update storage after restore")
+	}
+
+	h.LogInfoWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "descendantCount": len(restoredFileInfosOut)}, "restore complete")
+	return changelogEvents, nil
 }


### PR DESCRIPTION
## Summary

- Move storage counter UPSERTs out of the main restore transaction. They now run after commit via `NewSimpleStore`, so row locks on the hot `organization_storage` / `dataset_storage` rows aren't held across S3/DynamoDB calls. Addresses observed 3+ minute stalls when multiple restores run concurrently in the same org.
- Fix `restoreName` savepoint handling: on the aborted-tx path, rollback the savepoint and skip `RELEASE`, so callers see the original rename error instead of `current transaction is aborted, commands ignored until end of transaction block`.
- Broaden `UpdatePackageName` uniqueness detection to any `23505` on the name UPDATE (drop the constraint-name allowlist). The savepoint retry now actually fires when the unique index gets renamed by a migration.
- Add a `"restore complete"` log at the end of `handleFilePackage` / `handleFolderPackage` so silent hangs are distinguishable from silent successes.

## Context

A user reported that a restored file wasn't appearing in the files view. Tracing the restore lambda logs for `N:package:b6fe3921-...` showed 193 seconds between `restored size: 1232` and `END` with no log lines in between. RDS wasn't CPU-bound and connections were flat — contention on the hot `organization_storage` row (which every concurrent restore/delete/upload in the org touches) was the most plausible cause.

While investigating, two other restores in the same session failed with the aborted-tx error above, masking the real cause (a name uniqueness collision with a sibling package sharing the same filename).

## Test plan

- [x] `make test` passes locally (Docker Postgres + DynamoDB + MinIO)
- [x] `TestMessageHandler_handleFilePackage` (published + unpublished) still asserts storage table values after the tx change
- [x] `TestHandleMessage` end-to-end folder restore asserts storage counters for a 50-package hierarchy
- [x] `TestRestoreName*` / `TestQueries_UpdatePackageName/*duplicate_name` still pass
- [ ] After deploy: verify a concurrent restore batch in dev no longer shows the silent multi-minute gap in CloudWatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)