### PR TITLE
Gate /download-manifest on scan_status (block infected + failed)

### DIFF
--- a/api/models/download.go
+++ b/api/models/download.go
@@ -1,19 +1,27 @@
 package models
 
+import "database/sql"
+
 // DownloadRequest is the request body for POST /download-manifest.
 type DownloadRequest struct {
 	NodeIds []string `json:"nodeIds"`
 }
 
 // DownloadManifestResponse is the response for POST /download-manifest.
+// Blocked is populated when files are excluded from download due to
+// their scan status (currently: infected or failed). Clients should
+// surface both arrays — Data entries are directly downloadable, and
+// Blocked entries explain why the listed files were withheld.
 type DownloadManifestResponse struct {
-	Header DownloadManifestHeader  `json:"header"`
-	Data   []DownloadManifestEntry `json:"data"`
+	Header  DownloadManifestHeader         `json:"header"`
+	Data    []DownloadManifestEntry        `json:"data"`
+	Blocked []DownloadManifestBlockedEntry `json:"blocked,omitempty"`
 }
 
 type DownloadManifestHeader struct {
-	Count int   `json:"count"`
-	Size  int64 `json:"size"`
+	Count        int   `json:"count"`
+	Size         int64 `json:"size"`
+	BlockedCount int   `json:"blockedCount,omitempty"`
 }
 
 type DownloadManifestEntry struct {
@@ -24,6 +32,23 @@ type DownloadManifestEntry struct {
 	URL           string   `json:"url"`
 	Size          int64    `json:"size"`
 	FileExtension string   `json:"fileExtension,omitempty"`
+	// ScanStatus is the current malware-scan state of the file
+	// (see scan-service docs for the value vocabulary). Omitted if
+	// the row predates the scan_status migration. "clean",
+	// "unscanned", "pending", and similar pass-through values are
+	// surfaced here so the UI can render an appropriate indicator;
+	// "infected" / "failed" never appear in Data (they're in Blocked).
+	ScanStatus string `json:"scanStatus,omitempty"`
+}
+
+// DownloadManifestBlockedEntry is returned for files that were
+// excluded from Data because of a blocking scan status. It omits the
+// presigned URL by design — the client should not attempt download.
+type DownloadManifestBlockedEntry struct {
+	NodeId      string `json:"nodeId"`
+	FileName    string `json:"fileName"`
+	PackageName string `json:"packageName"`
+	ScanStatus  string `json:"scanStatus"`
 }
 
 // PackageHierarchyRow represents a single row from the recursive package hierarchy query.
@@ -44,4 +69,5 @@ type PackageHierarchyRow struct {
 	S3Bucket             string
 	S3Key                string
 	PublishedS3VersionId *string
+	ScanStatus           sql.NullString
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - $PWD:/go/src/github.com/pennsieve/packages-service
   pennsievedb:
-    image: pennsieve/pennsievedb:V20260409120000-seed
+    image: pennsieve/pennsievedb:V20260420120100-seed
     restart: always
   #    command: [ "postgres", "-c", "log_statement=all" ]
   minio:

--- a/lambda/service/handler/download.go
+++ b/lambda/service/handler/download.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -109,11 +110,29 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 	presignClient := s3.NewPresignClient(S3Client)
 
 	var entries []models.DownloadManifestEntry
+	var blocked []models.DownloadManifestBlockedEntry
 	var totalSize int64
 
 	bucketOptionsCache := NewBucketOptionsCache(AssumeRoleClient, stsCredentialsDuration, h.externalBucketConfig)
 
 	for _, row := range rows {
+		// Gate on scan_status. See pennsieve/scan-service/docs/developer.md
+		// §12 for the permissive-during-scan policy: infected/failed
+		// are blocked (no URL emitted); pending/scanning/clean/unscanned/
+		// not_required pass through with the status surfaced to the
+		// client. Null scan_status (pre-migration rows) is treated as
+		// clean — permissive default.
+		scanStatus := normalizeScanStatus(row.ScanStatus)
+		if scanStatusBlocks(scanStatus) {
+			blocked = append(blocked, models.DownloadManifestBlockedEntry{
+				NodeId:      row.NodeId,
+				FileName:    row.FileName,
+				PackageName: row.PackageName,
+				ScanStatus:  scanStatus,
+			})
+			continue
+		}
+
 		s3Bucket := row.S3Bucket
 		bucketOptions := bucketOptionsCache.Get(s3Bucket)
 
@@ -152,20 +171,47 @@ func (h *DownloadManifestHandler) post(ctx context.Context) (*events.APIGatewayV
 			URL:           presignResult.URL,
 			Size:          row.Size,
 			FileExtension: getFullExtension(row.S3Key),
+			ScanStatus:    scanStatus,
 		})
 		totalSize += row.Size
 	}
 
 	resp := models.DownloadManifestResponse{
 		Header: models.DownloadManifestHeader{
-			Count: len(entries),
-			Size:  totalSize,
+			Count:        len(entries),
+			Size:         totalSize,
+			BlockedCount: len(blocked),
 		},
-		Data: entries,
+		Data:    entries,
+		Blocked: blocked,
 	}
 
-	h.logger.Infof("download manifest: %d files, %d bytes for %d requested packages", len(entries), totalSize, len(request.NodeIds))
+	h.logger.Infof("download manifest: %d files (%d bytes), %d blocked, for %d requested packages", len(entries), totalSize, len(blocked), len(request.NodeIds))
 	return h.buildResponse(resp, http.StatusOK)
+}
+
+// scan_status values that prevent a presigned URL from being issued.
+// See scan-service developer docs §12.
+const (
+	scanStatusInfected = "infected"
+	scanStatusFailed   = "failed"
+)
+
+func scanStatusBlocks(s string) bool {
+	switch s {
+	case scanStatusInfected, scanStatusFailed:
+		return true
+	}
+	return false
+}
+
+// normalizeScanStatus turns a nullable DB scan_status into a plain
+// string: null / empty → "" (pre-migration rows, permissive default).
+func normalizeScanStatus(s sql.NullString) string {
+	if !s.Valid {
+		return ""
+	}
+	return s.String
 }
 
 // getPackageHierarchy runs the recursive CTE to resolve package node IDs into
@@ -207,7 +253,8 @@ func (h *DownloadManifestHandler) getPackageHierarchy(ctx context.Context, orgId
 			f.file_type,
 			f.s3_bucket,
 			f.s3_key,
-            f.published_s3_version_id
+            f.published_s3_version_id,
+            f.scan_status
 		FROM parents
 		JOIN "%[1]d".files f ON f.package_id = parents.id
 		JOIN (
@@ -247,6 +294,7 @@ func (h *DownloadManifestHandler) getPackageHierarchy(ctx context.Context, orgId
 			&row.S3Bucket,
 			&row.S3Key,
 			&row.PublishedS3VersionId,
+			&row.ScanStatus,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan hierarchy row: %w", err)
 		}

--- a/lambda/service/handler/download_test.go
+++ b/lambda/service/handler/download_test.go
@@ -441,6 +441,61 @@ func TestDownloadManifest_NonexistentPackage(t *testing.T) {
 	assert.Empty(t, manifest.Data)
 }
 
+// TestDownloadManifest_ScanStatusGating verifies that files with
+// scan_status='infected' or 'failed' are routed into the Blocked
+// array (no presigned URL issued), while pending and clean pass
+// through to Data with their scan status surfaced.
+//
+// There is no null-scan-status case here: the migration adds
+// scan_status as NOT NULL DEFAULT 'pending', so pre-existing rows
+// land on 'pending' rather than NULL. The handler's null-tolerant
+// normalizeScanStatus is kept as a defensive fallback only.
+func TestDownloadManifest_ScanStatusGating(t *testing.T) {
+	setupDownloadTestDB(t)
+	setupS3Client(t)
+	setupExternalBucketConfig(t, nil)
+
+	body, _ := json.Marshal(models.DownloadRequest{NodeIds: []string{
+		"N:package:dl-infected",
+		"N:package:dl-failed",
+		"N:package:dl-pending",
+		"N:package:dl-clean",
+	}})
+	req := newTestRequest("POST", "/download-manifest", "test-req-scan",
+		map[string]string{"dataset_id": "N:dataset:dl-test"}, string(body))
+	handler := NewHandler(req, editorClaims(2, "N:dataset:dl-test")).WithDefaultService()
+
+	resp, err := handler.handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var manifest models.DownloadManifestResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &manifest))
+
+	// Data: clean + pending (2 files); Blocked: infected + failed (2 files).
+	assert.Equal(t, 2, manifest.Header.Count)
+	assert.Equal(t, 2, manifest.Header.BlockedCount)
+	require.Len(t, manifest.Data, 2)
+	require.Len(t, manifest.Blocked, 2)
+
+	byName := map[string]models.DownloadManifestEntry{}
+	for _, e := range manifest.Data {
+		byName[e.PackageName] = e
+	}
+	assert.Equal(t, "clean", byName["clean-file"].ScanStatus)
+	assert.Equal(t, "pending", byName["pending-file"].ScanStatus)
+	for _, e := range manifest.Data {
+		assert.NotEmpty(t, e.URL, "downloadable entries must have a presigned URL: %s", e.PackageName)
+	}
+
+	blockedByName := map[string]models.DownloadManifestBlockedEntry{}
+	for _, b := range manifest.Blocked {
+		blockedByName[b.PackageName] = b
+	}
+	assert.Equal(t, "infected", blockedByName["infected-file"].ScanStatus)
+	assert.Equal(t, "failed", blockedByName["failed-file"].ScanStatus)
+}
+
 func TestGetFullExtension(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/lambda/service/handler/testdata/download-manifest-test.sql
+++ b/lambda/service/handler/testdata/download-manifest-test.sql
@@ -56,3 +56,22 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES
     (5007, 3006, 'non-us-image.ome.tiff', 'OMETIFF', 'pennsieve-test-storage-afs1', '15/files/non-us-image.ome.tiff','source', 8192, '{}', '00000000-0000-0000-0000-000000005007', 'unprocessed', 'uploaded', '2023-01-01 00:00:00', '2023-01-01 00:00:00')
 ON CONFLICT (id) DO NOTHING;
+
+-- scan-status packages (one package per status to exercise the scan_status gating in download.go):
+--   3010 infected  → Blocked with scan_status='infected'
+--   3011 failed    → Blocked with scan_status='failed'
+--   3012 pending   → Data with scan_status='pending' (permissive during scan)
+--   3013 clean     → Data with scan_status='clean'
+INSERT INTO "2".packages (id, name, type, state, dataset_id, parent_id, updated_at, created_at, attributes, node_id, size, owner_id, import_id) VALUES
+(3010, 'infected-file',  'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-infected',  null, 1, '00000000-0000-0000-0000-000000003010'),
+(3011, 'failed-file',    'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-failed',    null, 1, '00000000-0000-0000-0000-000000003011'),
+(3012, 'pending-file',   'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-pending',   null, 1, '00000000-0000-0000-0000-000000003012'),
+(3013, 'clean-file',     'Text', 'READY', 300, null, '2023-01-01 00:00:00', '2023-01-01 00:00:00', '[]', 'N:package:dl-clean',     null, 1, '00000000-0000-0000-0000-000000003013')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO "2".files (id, package_id, name, file_type, s3_bucket, s3_key, object_type, size, checksum, uuid, processing_state, uploaded_state, scan_status, created_at, updated_at) VALUES
+(5010, 3010, 'infected.bin', 'Text', 'pennsieve-test-storage', 'org2/infected.bin', 'source', 100, '{}', '00000000-0000-0000-0000-000000005010', 'unprocessed', 'uploaded', 'infected', '2023-01-01 00:00:00', '2023-01-01 00:00:00'),
+(5011, 3011, 'failed.bin',   'Text', 'pennsieve-test-storage', 'org2/failed.bin',   'source', 100, '{}', '00000000-0000-0000-0000-000000005011', 'unprocessed', 'uploaded', 'failed',   '2023-01-01 00:00:00', '2023-01-01 00:00:00'),
+(5012, 3012, 'pending.bin',  'Text', 'pennsieve-test-storage', 'org2/pending.bin',  'source', 100, '{}', '00000000-0000-0000-0000-000000005012', 'unprocessed', 'uploaded', 'pending',  '2023-01-01 00:00:00', '2023-01-01 00:00:00'),
+(5013, 3013, 'clean.bin',    'Text', 'pennsieve-test-storage', 'org2/clean.bin',    'source', 100, '{}', '00000000-0000-0000-0000-000000005013', 'unprocessed', 'uploaded', 'clean',    '2023-01-01 00:00:00', '2023-01-01 00:00:00')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
First piece of Phase 3a enforcement (see \`scan-service/docs/developer.md\` §12.3). The bulk download endpoint \`POST /download-manifest\` now reads \`scan_status\` from the per-org \`files\` table and routes each file into one of two response arrays:

| scan_status | Response | URL? | ScanStatus surfaced? |
|---|---|---|---|
| \`clean\` / \`format_validated\` / \`unscanned\` / \`not_required\` | Data | Yes | Yes (for client to render) |
| \`pending\` / \`scanning\` | Data | Yes | Yes (in-progress indicator) |
| \`infected\` / \`failed\` | **Blocked** | No | Yes (reason for user) |
| NULL (pre-migration, defensive fallback) | Data | Yes | Omitted |

The migration installs \`scan_status TEXT NOT NULL DEFAULT 'pending'\` — so NULL shouldn't appear in practice post-migration, but the handler treats it as permissive as a defensive fallback.

## Response shape (additive)
\`\`\`json
{
  "header": { "count": 2, "size": 200, "blockedCount": 2 },
  "data":    [ { "nodeId": "...", "url": "...", "scanStatus": "clean", ... } ],
  "blocked": [ { "nodeId": "...", "fileName": "...", "packageName": "...", "scanStatus": "infected" } ]
}
\`\`\`

\`header.blockedCount\` and \`manifest.blocked\` are new; existing clients ignoring those fields continue to work (blocked files simply don't appear in \`Data\`).

## Changes
- \`api/models/download.go\`: add \`ScanStatus sql.NullString\` to \`PackageHierarchyRow\`; add \`DownloadManifestBlockedEntry\`; extend response + header.
- \`lambda/service/handler/download.go\`: add \`f.scan_status\` to the recursive-CTE SELECT + Scan; new \`scanStatusBlocks\` + \`normalizeScanStatus\` helpers; per-row routing in the presign loop; log line reports clean + blocked counts.
- \`lambda/service/handler/testdata/download-manifest-test.sql\`: four new packages (\`dl-infected\`, \`dl-failed\`, \`dl-pending\`, \`dl-clean\`) with explicit scan_status values.
- \`lambda/service/handler/download_test.go\`: \`TestDownloadManifest_ScanStatusGating\` covers all four states end-to-end (verifies routing + URL issuance + scanStatus echo).
- \`docker-compose.test.yml\`: bump pennsievedb image from \`V20260409120000-seed\` → \`V20260420120100-seed\` so the test container has the \`scan_status\` column. Image is already published on DockerHub.

## Test plan
- [x] \`make test-ci\` — full suite passes including the new scan-status test.
- [ ] Deploy to dev; upload an EICAR test file; call \`POST /download-manifest\` with that file's \`nodeId\`; confirm it lands in \`blocked\` with \`scanStatus=infected\`.
- [ ] Same with a normal file: \`data\` entry carries \`scanStatus=clean\`.

## Follow-ups
- **pennsieve-api (Scala)** has three more presign paths (\`GET /packages/{id}/files/{id}\`, regex variant, \`POST /packages/download-manifest\`). Same gating logic ported to Scala — separate PR.
- **UI surfacing** in pennsieve-app (file detail, download button disabled for blocked) — Phase 3b.
- **S3 tag + bucket-policy enforcement** — Phase 3e defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)