### PR TITLE
Publish FileFinalized rescan trigger on package restore

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,11 +1,9 @@
 module github.com/pennsieve/packages-service/api
 
-go 1.23
-
-toolchain go1.23.12
+go 1.24
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.39.6
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.31.19
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.23
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.22
@@ -23,8 +21,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.3 // indirect
@@ -33,10 +31,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 // indirect
-	github.com/aws/smithy-go v1.23.2 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.39.6 h1:2JrPCVgWJm7bm83BDwY5z8ietmeJUbh3O2ACnn+Xsqk=
 github.com/aws/aws-sdk-go-v2 v1.39.6/go.mod h1:c9pm7VwuW0UPxAEYGyTmyurVcNrbF6Rt/wixFqDhcjE=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 h1:DHctwEM8P8iTXFxC/QK0MRjwEpWQeM9yzidCRjldUz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3/go.mod h1:xdCzcZEtnSTKVDOmUZs4l/j3pSV6rpo1WXl5ugNsL8Y=
 github.com/aws/aws-sdk-go-v2/config v1.31.19 h1:qdUtOw4JhZr2YcKO3g0ho/IcFXfXrrb8xlX05Y6EvSw=
@@ -14,8 +16,12 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 h1:Ld4Pn4f+XtxxNvQRjeyyhNv
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13/go.mod h1:vdo6tHMnHd4hfQuqN/IaWt4NZxFOGVoxbae20uq5Fh4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13 h1:a+8/MLcWlIxo1lF9xaGt3J/u3yOZx+CdSveSNwjhD40=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13/go.mod h1:oGnKwIYZ4XttyU2JWxFrwvhF6YKiK/9/wmE3v3Iu9K8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 h1:HBSI2kDkMdWz4ZM7FjwE7e/pWDEZ+nR95x8Ztet1ooY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13/go.mod h1:YE94ZoDArI7awZqJzBAZ3PDD2zSfuP7w6P2knOzIn8M=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
@@ -36,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 h1:zhBJXdhWIFZ1a
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13/go.mod h1:JaaOeCE368qn2Hzi3sEzY6FgAZVCIYcC2nwbro2QCh8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1 h1:kKJk9r6iLMfCGy8RL9GWg3n9gUE1IpSwqYP3/5bdL1s=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1/go.mod h1:+wArOOrcHUevqdto9k1tKOF5++YTe9JEcPSc9Tx2ZSw=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 h1:synXIPC/L4Cc489P0XDcrVJzHSLj7krKRpFLalbGM2k=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.17/go.mod h1:4ABZnI23uNK37waIjGwkubnCwGhepIt9x1GvASfljJA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14 h1:VB/VRA5FLpYqUMR9jHyihkg2qTk2u7MIkwKFKf2870Y=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14/go.mod h1:ZS67woOy/ftzvKK2+P53u2NPqImAPTWz+hBn+tchP7k=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 h1:/p6MxkbQoCzaGQT3WO0JwG0FlQyG9RD8VmdmoKc5xqU=
@@ -46,6 +54,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 h1:5sbIM57lHLaEaNWdIx23JH30LNBs
 github.com/aws/aws-sdk-go-v2/service/sts v1.40.1/go.mod h1:E19xDjpzPZC7LS2knI9E6BaRFDK43Eul7vd6rSq2HWk=
 github.com/aws/smithy-go v1.23.2 h1:Crv0eatJUQhaManss33hS5r40CG3ZFH+21XSkqMrIUM=
 github.com/aws/smithy-go v1.23.2/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/api/service/service_test.go
+++ b/api/service/service_test.go
@@ -249,6 +249,10 @@ func (m *MockPackagesStore) GetSourceFilesByNodeIds(ctx context.Context, package
 	panic("mock me if you need me")
 }
 
+func (m *MockPackagesStore) GetFilesNeedingRescanByPackageId(_ context.Context, _ int64) ([]store.RescanFileRow, error) {
+	panic("mock me if you need me")
+}
+
 func (m *MockPackagesStore) NewSavepoint(_ context.Context, _ string) error {
 	panic("mock me if you need me")
 }

--- a/api/store/postgres.go
+++ b/api/store/postgres.go
@@ -229,6 +229,49 @@ func (q *Queries) GetSourceFilesByPackageId(ctx context.Context, packageId int64
 	return files, nil
 }
 
+// RescanFileRow is the projection used by the restore handler to
+// publish FileFinalized events for files whose scan_status indicates a
+// scan never completed. Kept distinct from File so the existing
+// GetSourceFilesByPackageId callers don't grow new fields they ignore.
+type RescanFileRow struct {
+	ID       int64
+	UUID     string
+	S3Bucket string
+	S3Key    string
+	Size     int64
+}
+
+// GetFilesNeedingRescanByPackageId returns source files for the given
+// package whose scan_status is NULL, 'pending', or 'failed' — i.e. files
+// for which there is no successful terminal verdict yet. The restore
+// handler uses this to decide which files to publish to the scan
+// trigger topic after a package comes out of trash.
+func (q *Queries) GetFilesNeedingRescanByPackageId(ctx context.Context, packageId int64) ([]RescanFileRow, error) {
+	query := fmt.Sprintf(`SELECT id, uuid, s3_bucket, s3_key, size
+		FROM "%d".files
+		WHERE package_id = $1
+		AND object_type = $2
+		AND (scan_status IS NULL OR scan_status IN ('pending', 'failed'))`, q.OrgId)
+	rows, err := q.db.QueryContext(ctx, query, packageId, objectType.Source.String())
+	if err != nil {
+		return nil, fmt.Errorf("error getting files needing rescan: %w", err)
+	}
+	defer q.closeRows(rows)
+
+	var out []RescanFileRow
+	for rows.Next() {
+		var r RescanFileRow
+		if err := rows.Scan(&r.ID, &r.UUID, &r.S3Bucket, &r.S3Key, &r.Size); err != nil {
+			return nil, fmt.Errorf("error scanning rescan file row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error on rescan file rows iteration: %w", err)
+	}
+	return out, nil
+}
+
 func (q *Queries) GetSourceFilesByNodeIds(ctx context.Context, packageNodeIds []string) (map[string][]File, error) {
 	if len(packageNodeIds) == 0 {
 		return map[string][]File{}, nil
@@ -457,5 +500,7 @@ type SQLStore interface {
 	// GetSourceFilesByPackageId returns Files that have the object type "source" for the given package.
 	GetSourceFilesByPackageId(ctx context.Context, packageId int64) ([]File, error)
 	GetSourceFilesByNodeIds(ctx context.Context, packageNodeIds []string) (map[string][]File, error)
+	// GetFilesNeedingRescanByPackageId returns files in the package whose scan_status indicates no successful terminal verdict (NULL, 'pending', or 'failed').
+	GetFilesNeedingRescanByPackageId(ctx context.Context, packageId int64) ([]RescanFileRow, error)
 	logging.Logger
 }

--- a/api/store/restore/scanTrigger.go
+++ b/api/store/restore/scanTrigger.go
@@ -1,0 +1,144 @@
+package restore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/google/uuid"
+	"github.com/pennsieve/packages-service/api/logging"
+	log "github.com/sirupsen/logrus"
+)
+
+const FileFinalizedTopicEnvKey = "FILE_FINALIZED_TOPIC_ARN"
+
+// RescanFile is the minimal projection needed to publish a scan-trigger
+// event. Sourced from a per-org files row for a package being restored
+// from trash.
+type RescanFile struct {
+	FileID   int64
+	FileUUID string
+	S3Bucket string
+	S3Key    string
+	Size     int64
+}
+
+// fileFinalizedEvent mirrors the field set scan-service actually reads
+// (scan-service/cmd/scanner/main.go references FileID, OrganizationID,
+// FileUUID, S3Bucket, S3Key, Size — nothing else). manifestId / fileType /
+// extension / checksum / complianceTier / datasetId / timestamp / traceId
+// are intentionally omitted: scan-service ignores them, and a restore-
+// triggered event has no upload-session manifest to honestly cite.
+type fileFinalizedEvent struct {
+	EventType      string `json:"eventType"`
+	EventVersion   int    `json:"eventVersion"`
+	FileID         int64  `json:"fileId"`
+	FileUUID       string `json:"fileUUID"`
+	S3Bucket       string `json:"s3Bucket"`
+	S3Key          string `json:"s3Key"`
+	Size           int64  `json:"size"`
+	OrganizationID int    `json:"organizationId"`
+}
+
+type ScanTriggerStore interface {
+	PublishRescanRequests(ctx context.Context, orgId int, files []RescanFile) error
+	logging.Logger
+}
+
+// SNSPublisher is the subset of the SNS client we use; lets tests inject
+// a fake without standing up a real SNS endpoint.
+type SNSPublisher interface {
+	PublishBatch(ctx context.Context, params *sns.PublishBatchInput, optFns ...func(*sns.Options)) (*sns.PublishBatchOutput, error)
+}
+
+type SNSScanTriggerStore struct {
+	Client   SNSPublisher
+	TopicArn string
+}
+
+func NewSNSScanTriggerStore(snsClient SNSPublisher, topicArn string) *SNSScanTriggerStore {
+	return &SNSScanTriggerStore{Client: snsClient, TopicArn: topicArn}
+}
+
+func (s *SNSScanTriggerStore) WithLogging(log *logging.Log) ScanTriggerStore {
+	return &snsScanTriggerStore{
+		SNSScanTriggerStore: s,
+		Log:                 log,
+	}
+}
+
+type snsScanTriggerStore struct {
+	*SNSScanTriggerStore
+	*logging.Log
+}
+
+const scanTriggerBatchSize = 10
+
+// PublishRescanRequests emits one FileFinalized event per file to the
+// FileFinalized SNS topic, in PublishBatch chunks. A missing topic ARN
+// (local/test env) is a no-op. Caller treats errors as best-effort —
+// a publish failure must not roll back a successful restore.
+func (s *snsScanTriggerStore) PublishRescanRequests(ctx context.Context, orgId int, files []RescanFile) error {
+	if s.TopicArn == "" || len(files) == 0 {
+		return nil
+	}
+
+	entries := make([]snstypes.PublishBatchRequestEntry, 0, scanTriggerBatchSize)
+	for _, f := range files {
+		evt := fileFinalizedEvent{
+			EventType:      "FileFinalized",
+			EventVersion:   1,
+			FileID:         f.FileID,
+			FileUUID:       f.FileUUID,
+			S3Bucket:       f.S3Bucket,
+			S3Key:          f.S3Key,
+			Size:           f.Size,
+			OrganizationID: orgId,
+		}
+		body, err := json.Marshal(evt)
+		if err != nil {
+			s.LogWarnWithFields(log.Fields{"fileId": f.FileID, "error": err}, "scan trigger marshal failed; skipping file")
+			continue
+		}
+		entries = append(entries, snstypes.PublishBatchRequestEntry{
+			Id:      aws.String(uuid.NewString()),
+			Message: aws.String(string(body)),
+			MessageAttributes: map[string]snstypes.MessageAttributeValue{
+				"eventType": {DataType: aws.String("String"), StringValue: aws.String("FileFinalized")},
+			},
+		})
+		if len(entries) == scanTriggerBatchSize {
+			if err := s.publishBatch(ctx, entries); err != nil {
+				return err
+			}
+			entries = entries[:0]
+		}
+	}
+	if len(entries) > 0 {
+		if err := s.publishBatch(ctx, entries); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *snsScanTriggerStore) publishBatch(ctx context.Context, entries []snstypes.PublishBatchRequestEntry) error {
+	out, err := s.Client.PublishBatch(ctx, &sns.PublishBatchInput{
+		TopicArn:                   aws.String(s.TopicArn),
+		PublishBatchRequestEntries: entries,
+	})
+	if err != nil {
+		return fmt.Errorf("scan trigger PublishBatch: %w", err)
+	}
+	for _, f := range out.Failed {
+		s.LogWarnWithFields(log.Fields{
+			"id":   aws.ToString(f.Id),
+			"code": aws.ToString(f.Code),
+			"msg":  aws.ToString(f.Message),
+		}, "scan trigger PublishBatch entry failed")
+	}
+	return nil
+}

--- a/lambda/restore/go.mod
+++ b/lambda/restore/go.mod
@@ -1,14 +1,12 @@
 module github.com/pennsieve/packages-service/restore
 
-go 1.23
-
-toolchain go1.23.12
+go 1.24
 
 replace github.com/pennsieve/packages-service/api => ../../api
 
 require (
 	github.com/aws/aws-lambda-go v1.38.0
-	github.com/aws/aws-sdk-go-v2 v1.39.6
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.31.19
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.22
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.52.5
@@ -26,8 +24,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.3 // indirect
@@ -36,10 +34,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 // indirect
-	github.com/aws/smithy-go v1.23.2 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/lambda/restore/go.sum
+++ b/lambda/restore/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.38.0 h1:4CUdxGzvuQp0o8Zh7KtupB9XvCiiY8yKqJtzco+g
 github.com/aws/aws-lambda-go v1.38.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
 github.com/aws/aws-sdk-go-v2 v1.39.6 h1:2JrPCVgWJm7bm83BDwY5z8ietmeJUbh3O2ACnn+Xsqk=
 github.com/aws/aws-sdk-go-v2 v1.39.6/go.mod h1:c9pm7VwuW0UPxAEYGyTmyurVcNrbF6Rt/wixFqDhcjE=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 h1:DHctwEM8P8iTXFxC/QK0MRjwEpWQeM9yzidCRjldUz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3/go.mod h1:xdCzcZEtnSTKVDOmUZs4l/j3pSV6rpo1WXl5ugNsL8Y=
 github.com/aws/aws-sdk-go-v2/config v1.31.19 h1:qdUtOw4JhZr2YcKO3g0ho/IcFXfXrrb8xlX05Y6EvSw=
@@ -16,8 +18,12 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 h1:Ld4Pn4f+XtxxNvQRjeyyhNv
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13/go.mod h1:vdo6tHMnHd4hfQuqN/IaWt4NZxFOGVoxbae20uq5Fh4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13 h1:a+8/MLcWlIxo1lF9xaGt3J/u3yOZx+CdSveSNwjhD40=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.13/go.mod h1:oGnKwIYZ4XttyU2JWxFrwvhF6YKiK/9/wmE3v3Iu9K8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 h1:HBSI2kDkMdWz4ZM7FjwE7e/pWDEZ+nR95x8Ztet1ooY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13/go.mod h1:YE94ZoDArI7awZqJzBAZ3PDD2zSfuP7w6P2knOzIn8M=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
@@ -38,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 h1:zhBJXdhWIFZ1a
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13/go.mod h1:JaaOeCE368qn2Hzi3sEzY6FgAZVCIYcC2nwbro2QCh8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1 h1:kKJk9r6iLMfCGy8RL9GWg3n9gUE1IpSwqYP3/5bdL1s=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1/go.mod h1:+wArOOrcHUevqdto9k1tKOF5++YTe9JEcPSc9Tx2ZSw=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 h1:synXIPC/L4Cc489P0XDcrVJzHSLj7krKRpFLalbGM2k=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.17/go.mod h1:4ABZnI23uNK37waIjGwkubnCwGhepIt9x1GvASfljJA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14 h1:VB/VRA5FLpYqUMR9jHyihkg2qTk2u7MIkwKFKf2870Y=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14/go.mod h1:ZS67woOy/ftzvKK2+P53u2NPqImAPTWz+hBn+tchP7k=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 h1:/p6MxkbQoCzaGQT3WO0JwG0FlQyG9RD8VmdmoKc5xqU=
@@ -48,6 +56,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 h1:5sbIM57lHLaEaNWdIx23JH30LNBs
 github.com/aws/aws-sdk-go-v2/service/sts v1.40.1/go.mod h1:E19xDjpzPZC7LS2knI9E6BaRFDK43Eul7vd6rSq2HWk=
 github.com/aws/smithy-go v1.23.2 h1:Crv0eatJUQhaManss33hS5r40CG3ZFH+21XSkqMrIUM=
 github.com/aws/smithy-go v1.23.2/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lambda/restore/handler/file.go
+++ b/lambda/restore/handler/file.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pennsieve/packages-service/api/models"
 	"github.com/pennsieve/packages-service/api/store"
+	"github.com/pennsieve/packages-service/api/store/restore"
 	"github.com/pennsieve/pennsieve-go-core/pkg/changelog"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
@@ -28,6 +29,7 @@ var savepointReplacer = strings.NewReplacer(":", "", "-", "")
 func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datasetId int64, restoreInfo models.RestorePackageInfo) ([]changelog.PackageRestoreEvent, error) {
 	var changelogEvents []changelog.PackageRestoreEvent
 	var restoredSize int64
+	var rescanCandidates []store.RescanFileRow
 	err := h.Store.SQLFactory.ExecStoreTx(ctx, orgId, func(sqlStore store.SQLStore) error {
 		// mark any deleted ancestors as restoring
 		var ancestors []models.RestorePackageInfo
@@ -100,6 +102,17 @@ func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datas
 		restoredSize = sourceFileSize(sourceFiles)
 		sqlStore.LogInfo("restored size: ", restoredSize)
 
+		// capture files needing rescan for post-commit SNS publish.
+		// Read inside the tx so we see a consistent post-restore view;
+		// publish outside it because SNS is best-effort.
+		if h.Store.ScanTrigger != nil {
+			rescan, err := sqlStore.GetFilesNeedingRescanByPackageId(ctx, restoreInfo.Id)
+			if err != nil {
+				return h.errorf("error querying files needing rescan for package %s: %w", restoreInfo.NodeId, err)
+			}
+			rescanCandidates = rescan
+		}
+
 		// restore states
 		stateRestores := make([]*models.RestorePackageInfo, len(ancestors)+1)
 		stateRestores[0] = &restoreInfo
@@ -122,6 +135,18 @@ func (h *MessageHandler) handleFilePackage(ctx context.Context, orgId int, datas
 	simpleStore := h.Store.SQLFactory.NewSimpleStore(orgId)
 	if storageErr := h.restoreStorage(ctx, int64(orgId), datasetId, restoreInfo, restoredSize, simpleStore); storageErr != nil {
 		h.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "error": storageErr}, "could not update storage after restore")
+	}
+
+	if h.Store.ScanTrigger != nil && len(rescanCandidates) > 0 {
+		files := make([]restore.RescanFile, len(rescanCandidates))
+		for i, r := range rescanCandidates {
+			files[i] = restore.RescanFile{FileID: r.ID, FileUUID: r.UUID, S3Bucket: r.S3Bucket, S3Key: r.S3Key, Size: r.Size}
+		}
+		if pubErr := h.Store.ScanTrigger.PublishRescanRequests(ctx, orgId, files); pubErr != nil {
+			h.LogErrorWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "fileCount": len(files), "error": pubErr}, "could not publish rescan triggers after restore")
+		} else {
+			h.LogInfoWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "fileCount": len(files)}, "published rescan triggers")
+		}
 	}
 
 	h.LogInfoWithFields(log.Fields{"nodeId": restoreInfo.NodeId, "size": restoredSize}, "restore complete")

--- a/lambda/restore/handler/file_test.go
+++ b/lambda/restore/handler/file_test.go
@@ -3,15 +3,19 @@ package handler
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/google/uuid"
 	"github.com/pennsieve/packages-service/api/models"
 	"github.com/pennsieve/packages-service/api/store"
+	"github.com/pennsieve/packages-service/api/store/restore"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/fileInfo/objectType"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
@@ -120,7 +124,7 @@ func TestRestoreName(t *testing.T) {
 		db.ExecSQLFile("restore-package-name-test.sql")
 		sqlFactory := store.NewPostgresStoreFactory(db.DB)
 		ctx := context.Background()
-		messageHandler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil))
+		messageHandler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil, nil))
 		restoreInfo := models.RestorePackageInfo{
 			Id:     d.id,
 			NodeId: d.nodeId,
@@ -166,7 +170,7 @@ func TestRestoreName_ConflictWithDeletedFile(t *testing.T) {
 
 	sqlFactory := store.NewPostgresStoreFactory(db.DB)
 	ctx := context.Background()
-	handler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil))
+	handler := NewMessageHandler(events.SQSMessage{}, NewBaseStore(sqlFactory, nil, nil, nil, nil))
 	originalName := "root-dir"
 	restoreInfo1 := models.RestorePackageInfo{
 		Id:     5,
@@ -285,7 +289,9 @@ func TestMessageHandler_handleFilePackage(t *testing.T) {
 			sqlFactory := store.NewPostgresStoreFactory(subDB.DB)
 			dyStore := store.NewDynamoDBStore(dyClient, deleteRecordTableName)
 			objectStore := store.NewS3Store(s3Client)
-			handler := NewMessageHandler(events.SQSMessage{MessageId: uuid.NewString(), Body: "{}"}, NewBaseStore(sqlFactory, dyStore, objectStore, nil))
+			fakeSNS := &fakeSNSPublisher{}
+			scanTriggerStore := restore.NewSNSScanTriggerStore(fakeSNS, "arn:aws:sns:us-east-1:000000000000:test-file-finalized")
+			handler := NewMessageHandler(events.SQSMessage{MessageId: uuid.NewString(), Body: "{}"}, NewBaseStore(sqlFactory, dyStore, objectStore, nil, scanTriggerStore))
 			restoreInfo := models.RestorePackageInfo{
 				Id:     tt.sourcePackage.Package.Id,
 				NodeId: tt.sourcePackage.Package.NodeId,
@@ -334,9 +340,60 @@ func TestMessageHandler_handleFilePackage(t *testing.T) {
 			// All delete records have been removed
 			assert.Zero(t, scanOut.ScannedCount)
 			assert.Empty(t, scanOut.Items)
+
+			// Files default to scan_status='pending' from the migration,
+			// so each restored file should have produced one FileFinalized
+			// rescan event on the fake SNS topic.
+			publishedFiles := fakeSNS.publishedFileEvents(t)
+			require.Len(t, publishedFiles, len(tt.sourcePackage.Files))
+			gotFileIDs := make(map[int64]struct{}, len(publishedFiles))
+			for _, evt := range publishedFiles {
+				assert.Equal(t, "FileFinalized", evt.EventType)
+				assert.Equal(t, orgId, evt.OrganizationID)
+				assert.NotEmpty(t, evt.S3Bucket)
+				assert.NotEmpty(t, evt.S3Key)
+				gotFileIDs[evt.FileID] = struct{}{}
+			}
+			for _, f := range tt.sourcePackage.Files {
+				expectedID := int64(f.IntId(t))
+				_, ok := gotFileIDs[expectedID]
+				assert.True(t, ok, "expected published rescan event for fileId %d", expectedID)
+			}
 		})
 	}
 
+}
+
+// fakeSNSPublisher captures PublishBatch entries for assertion.
+type fakeSNSPublisher struct {
+	entries []snstypes.PublishBatchRequestEntry
+}
+
+func (f *fakeSNSPublisher) PublishBatch(_ context.Context, in *sns.PublishBatchInput, _ ...func(*sns.Options)) (*sns.PublishBatchOutput, error) {
+	f.entries = append(f.entries, in.PublishBatchRequestEntries...)
+	return &sns.PublishBatchOutput{}, nil
+}
+
+// publishedFileEvents decodes captured entry bodies into the projection
+// the test asserts on. Mirrors the field set scan-service reads.
+func (f *fakeSNSPublisher) publishedFileEvents(t require.TestingT) []capturedFileEvent {
+	out := make([]capturedFileEvent, 0, len(f.entries))
+	for _, e := range f.entries {
+		var evt capturedFileEvent
+		require.NoError(t, json.Unmarshal([]byte(aws.ToString(e.Message)), &evt))
+		out = append(out, evt)
+	}
+	return out
+}
+
+type capturedFileEvent struct {
+	EventType      string `json:"eventType"`
+	FileID         int64  `json:"fileId"`
+	FileUUID       string `json:"fileUUID"`
+	S3Bucket       string `json:"s3Bucket"`
+	S3Key          string `json:"s3Key"`
+	Size           int64  `json:"size"`
+	OrganizationID int    `json:"organizationId"`
 }
 
 type TestSourcePackage struct {

--- a/lambda/restore/handler/folder_test.go
+++ b/lambda/restore/handler/folder_test.go
@@ -81,7 +81,7 @@ func TestMessageHandler_handleFolderPackage(t *testing.T) {
 	sqlFactory := store.NewPostgresStoreFactory(db.DB)
 	dyStore := store.NewDynamoDBStore(dyClient, deleteRecordTableName)
 	objectStore := store.NewS3Store(s3Client)
-	handler := NewMessageHandler(events.SQSMessage{MessageId: uuid.NewString(), Body: "{}"}, NewBaseStore(sqlFactory, dyStore, objectStore, nil))
+	handler := NewMessageHandler(events.SQSMessage{MessageId: uuid.NewString(), Body: "{}"}, NewBaseStore(sqlFactory, dyStore, objectStore, nil, nil))
 	restoreInfo := models.RestorePackageInfo{
 		Id:     folderPackage.Id,
 		NodeId: folderPackage.NodeId,

--- a/lambda/restore/handler/handler.go
+++ b/lambda/restore/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	pennsievelog "github.com/pennsieve/packages-service/api/logging"
 	"github.com/pennsieve/packages-service/api/models"
@@ -25,20 +26,22 @@ var PennsieveDB *sql.DB
 var S3Client *s3.Client
 var DyDBClient *dynamodb.Client
 var SQSClient *sqs.Client
+var SNSClient *sns.Client
 
 type BaseStore interface {
 	NewStore(log *pennsievelog.Log) *Store
 }
 
 type baseStore struct {
-	sqlFactory *store.PostgresStoreFactory
-	dyDB       *store.DynamoDBStore
-	s3         *store.S3Store
-	changelog  *restore.SQSChangelogStore
+	sqlFactory  *store.PostgresStoreFactory
+	dyDB        *store.DynamoDBStore
+	s3          *store.S3Store
+	changelog   *restore.SQSChangelogStore
+	scanTrigger *restore.SNSScanTriggerStore
 }
 
-func NewBaseStore(sqlFactory *store.PostgresStoreFactory, dyDB *store.DynamoDBStore, s3 *store.S3Store, changelog *restore.SQSChangelogStore) BaseStore {
-	return &baseStore{sqlFactory: sqlFactory, dyDB: dyDB, s3: s3, changelog: changelog}
+func NewBaseStore(sqlFactory *store.PostgresStoreFactory, dyDB *store.DynamoDBStore, s3 *store.S3Store, changelog *restore.SQSChangelogStore, scanTrigger *restore.SNSScanTriggerStore) BaseStore {
+	return &baseStore{sqlFactory: sqlFactory, dyDB: dyDB, s3: s3, changelog: changelog, scanTrigger: scanTrigger}
 }
 
 func (b *baseStore) NewStore(log *pennsievelog.Log) *Store {
@@ -46,14 +49,19 @@ func (b *baseStore) NewStore(log *pennsievelog.Log) *Store {
 	objectStore := b.s3.WithLogging(log)
 	sqlFactory := b.sqlFactory.WithLogging(log)
 	changelog := b.changelog.WithLogging(log)
-	return &Store{NoSQL: noSQLStore, Object: objectStore, SQLFactory: sqlFactory, Changelog: changelog}
+	var scanTrigger restore.ScanTriggerStore
+	if b.scanTrigger != nil {
+		scanTrigger = b.scanTrigger.WithLogging(log)
+	}
+	return &Store{NoSQL: noSQLStore, Object: objectStore, SQLFactory: sqlFactory, Changelog: changelog, ScanTrigger: scanTrigger}
 }
 
 type Store struct {
-	SQLFactory store.SQLStoreFactory
-	Object     store.ObjectStore
-	NoSQL      store.NoSQLStore
-	Changelog  restore.ChangelogStore
+	SQLFactory  store.SQLStoreFactory
+	Object      store.ObjectStore
+	NoSQL       store.NoSQLStore
+	Changelog   restore.ChangelogStore
+	ScanTrigger restore.ScanTriggerStore
 }
 
 func RestorePackagesHandler(ctx context.Context, event events.SQSEvent) (events.SQSEventResponse, error) {
@@ -61,7 +69,11 @@ func RestorePackagesHandler(ctx context.Context, event events.SQSEvent) (events.
 	objectStore := store.NewS3Store(S3Client)
 	nosqlStore := store.NewDynamoDBStore(DyDBClient, os.Getenv(store.DeleteRecordTableNameEnvKey))
 	changelogStore := restore.NewSQSChangelogStore(SQSClient, os.Getenv(restore.JobsQueueIDEnvKey))
-	base := NewBaseStore(sqlFactory, nosqlStore, objectStore, changelogStore)
+	var scanTriggerStore *restore.SNSScanTriggerStore
+	if topicArn := os.Getenv(restore.FileFinalizedTopicEnvKey); topicArn != "" && SNSClient != nil {
+		scanTriggerStore = restore.NewSNSScanTriggerStore(SNSClient, topicArn)
+	}
+	base := NewBaseStore(sqlFactory, nosqlStore, objectStore, changelogStore, scanTriggerStore)
 	return handleBatches(ctx, event, base)
 }
 

--- a/lambda/restore/handler/handler_test.go
+++ b/lambda/restore/handler/handler_test.go
@@ -219,7 +219,7 @@ func TestHandleMessage(t *testing.T) {
 	objectStore := store.NewS3Store(s3Client)
 	nosqlStore := store.NewDynamoDBStore(dyClient, deleteRecordTableName)
 	sqsChangelogStore := restore.NewSQSChangelogStore(sqsClient, jobsQueueID)
-	base := NewBaseStore(sqlFactory, nosqlStore, objectStore, sqsChangelogStore)
+	base := NewBaseStore(sqlFactory, nosqlStore, objectStore, sqsChangelogStore, nil)
 	expectedMessageId := "handle-message-message-id"
 	message := events.SQSMessage{
 		MessageId: expectedMessageId,

--- a/lambda/restore/main.go
+++ b/lambda/restore/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/google/uuid"
 	"github.com/pennsieve/packages-service/restore/handler"
@@ -50,6 +51,7 @@ func init() {
 	handler.S3Client = s3.NewFromConfig(cfg)
 	handler.DyDBClient = dynamodb.NewFromConfig(cfg)
 	handler.SQSClient = sqs.NewFromConfig(cfg)
+	handler.SNSClient = sns.NewFromConfig(cfg)
 }
 
 func main() {

--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -1,17 +1,16 @@
 module github.com/pennsieve/packages-service/service
 
-go 1.23
-
-toolchain go1.23.4
+go 1.24
 
 replace github.com/pennsieve/packages-service/api => ../../api
 
 require (
 	github.com/aws/aws-lambda-go v1.34.1
-	github.com/aws/aws-sdk-go-v2 v1.41.0
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.31.19
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.23
 	github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign v1.9.13
+	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.14
@@ -28,9 +27,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.52.5 // indirect
@@ -42,7 +40,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -1,7 +1,7 @@
 github.com/aws/aws-lambda-go v1.34.1 h1:M3a/uFYBjii+tDcOJ0wL/WyFi2550FHoECdPf27zvOs=
 github.com/aws/aws-lambda-go v1.34.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
-github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
-github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 h1:DHctwEM8P8iTXFxC/QK0MRjwEpWQeM9yzidCRjldUz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3/go.mod h1:xdCzcZEtnSTKVDOmUZs4l/j3pSV6rpo1WXl5ugNsL8Y=
 github.com/aws/aws-sdk-go-v2/config v1.31.19 h1:qdUtOw4JhZr2YcKO3g0ho/IcFXfXrrb8xlX05Y6EvSw=
@@ -16,10 +16,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 h1:T1brd5dR3/fzNFAQch/iBK
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13/go.mod h1:Peg/GBAQ6JDt+RoBf4meB1wylmAipb7Kg2ZFakZTlwk=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13 h1:Ld4Pn4f+XtxxNvQRjeyyhNvL9FSmODuLnd0WzYBWoDw=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13/go.mod h1:vdo6tHMnHd4hfQuqN/IaWt4NZxFOGVoxbae20uq5Fh4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 h1:rgGwPzb82iBYSvHMHXc8h9mRoOUBZIGFgKb9qniaZZc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16/go.mod h1:L/UxsGeKpGoIj6DxfhOWHWQ/kGKcd4I1VncE4++IyKA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 h1:1jtGzuV7c82xnqOVfx2F0xmJcOw5374L7N6juGW6x6U=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16/go.mod h1:M2E5OQf+XLe+SZGmmpaI2yy+J326aFf6/+54PoxSANc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6 h1:0dES42T2dhICCbVB3JSTTn7+
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.6/go.mod h1:klO+ejMvYsB4QATfEOIXk8WAEwN4N0aBfJpvC+5SZBo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.40.1 h1:5sbIM57lHLaEaNWdIx23JH30LNBsSDkjN/QXGcRLAFc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.40.1/go.mod h1:E19xDjpzPZC7LS2knI9E6BaRFDK43Eul7vd6rSq2HWk=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -116,8 +116,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   # - sparc_bucket_role_arn: SPARC account buckets
   # - rejoin_bucket_role_arn: RE-JOIN and PRECISION account buckets (same account)
   statement {
-    sid    = "AssumeExternalPublishBucketRoles"
-    effect = "Allow"
+    sid     = "AssumeExternalPublishBucketRoles"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn,
@@ -163,8 +163,8 @@ data "aws_iam_policy_document" "packages_service_iam_policy_document" {
   }
 
   statement {
-    sid    = "PackagesServiceAssumeUploadCredentialsRole"
-    effect = "Allow"
+    sid       = "PackagesServiceAssumeUploadCredentialsRole"
+    effect    = "Allow"
     actions   = ["sts:AssumeRole"]
     resources = [aws_iam_role.viewer_assets_upload_credentials_role.arn]
   }
@@ -352,6 +352,21 @@ data "aws_iam_policy_document" "restore_package_iam_policy_document" {
 
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.jobs_kms_key_arn,
+    ]
+  }
+
+  // Re-publish FileFinalized so scan-service rescans files whose
+  // packages were just restored from trash.
+  statement {
+    sid    = "PublishScanRescanTriggers"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      data.terraform_remote_state.upload_service.outputs.file_finalized_topic_arn,
     ]
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "service_lambda" {
   s3_key        = "${var.service_name}/packages-service-${var.image_tag}.zip"
 
   vpc_config {
-    subnet_ids = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+    subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
     security_group_ids = [data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_security_group_id]
   }
 
@@ -25,9 +25,9 @@ resource "aws_lambda_function" "service_lambda" {
       CLOUDFRONT_KEY_ID                   = data.terraform_remote_state.platform_infrastructure.outputs.assets_distribution_public_key
       CLOUDFRONT_KEY_GROUP_ID             = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
       CLOUDFRONT_SIGNING_KEYS_SECRET_NAME = aws_secretsmanager_secret.cloudfront_signing_keys.name
-      UPLOAD_CREDENTIALS_ROLE_ARN              = aws_iam_role.viewer_assets_upload_credentials_role.arn
-      VIEWER_ASSETS_BUCKET                    = data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_id
-      EXTERNAL_BUCKETS_ROLE_MAP = jsonencode(local.external_bucket_roles)
+      UPLOAD_CREDENTIALS_ROLE_ARN         = aws_iam_role.viewer_assets_upload_credentials_role.arn
+      VIEWER_ASSETS_BUCKET                = data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_id
+      EXTERNAL_BUCKETS_ROLE_MAP           = jsonencode(local.external_bucket_roles)
     }
   }
 }
@@ -44,7 +44,7 @@ resource "aws_lambda_function" "restore_package_lambda" {
   s3_key        = "${var.service_name}/restore-package-${var.image_tag}.zip"
 
   vpc_config {
-    subnet_ids = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+    subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)
     security_group_ids = [data.terraform_remote_state.platform_infrastructure.outputs.upload_v2_security_group_id]
   }
 
@@ -57,6 +57,7 @@ resource "aws_lambda_function" "restore_package_lambda" {
       RESTORE_PACKAGE_QUEUE_URL         = aws_sqs_queue.restore_package_queue.url
       DELETE_RECORD_DYNAMODB_TABLE_NAME = data.terraform_remote_state.process_jobs_service.outputs.process_jobs_table_name
       JOBS_QUEUE_ID                     = data.terraform_remote_state.platform_infrastructure.outputs.jobs_queue_id,
+      FILE_FINALIZED_TOPIC_ARN          = data.terraform_remote_state.upload_service.outputs.file_finalized_topic_arn,
     }
   }
 }
@@ -77,7 +78,7 @@ resource "aws_lambda_function" "key_rotation" {
     variables = {
       ENVIRONMENT                     = var.environment_name
       CLOUDFRONT_KEY_GROUP_ID         = data.terraform_remote_state.platform_infrastructure.outputs.package_assets_key_group_id
-      KEY_ROTATION_GRACE_PERIOD_HOURS = "48"  # Grace period before removing old keys from CloudFront
+      KEY_ROTATION_GRACE_PERIOD_HOURS = "48" # Grace period before removing old keys from CloudFront
     }
   }
 


### PR DESCRIPTION
## Summary
When a package is restored from trash, files with no successful terminal scan verdict (`scan_status` in {NULL, 'pending', 'failed'}) now produce a fresh FileFinalized SNS event so scan-service rescans them.

## Why
PR #56 made `pending` permissive on download — the file is served while the scanner catches up. That's fine for the upload-then-scan flow because FileFinalized fires as soon as the upload commits. But the trash-restore path was a gap: a file uploaded *before* scan-service rolled out (or one that hit a DLQ pre-IAM-fix) sits at `pending` forever; deleting it puts the package in trash, and restoring it makes the file downloadable again at `pending` without ever being scanned.

This PR closes that gap. Restore now re-emits FileFinalized for files needing rescan; scan-service consumes via the existing fan-out and writes a real verdict.

Companion to scan-service PR #14 (skip-on-DELETED + S3-NoSuchKey-non-retryable). That PR is the foundation — without it a re-emitted FileFinalized for a restored file might race with a still-DELETED package state. With it, the post-restore path works naturally because:
- Package state is READY (or Uploaded) post-restore — doesn't trip the DELETED skip
- The delete marker has been removed by the existing restore handler — GetObject succeeds

## Minimal payload
scan-service reads only fileId, organizationId, fileUUID, s3Bucket, s3Key, size from the event. We omit manifestId, complianceTier, fileType, extension, checksum, datasetId, timestamp, traceId — scan-service ignores them, and a restore-triggered event has no honest upload-session manifest to cite. (Slimming the contract on the upload-service-v2 side too is a separate cleanup.)

## Changes
- api/store/restore/scanTrigger.go (new): SNSScanTriggerStore + ScanTriggerStore interface; PublishBatch in 10-entry chunks; SNSPublisher interface lets tests inject a fake.
- api/store/postgres.go: new GetFilesNeedingRescanByPackageId query with RescanFileRow projection (kept separate from File so existing callers don't grow ignored fields).
- lambda/restore/handler/file.go: in handleFilePackage, read rescan candidates inside the existing restore tx (consistent post-restore view); publish after commit as best-effort — a publish failure logs but doesn't roll back the restore, matching prior storage-update semantics.
- lambda/restore/handler/handler.go: BaseStore/Store extended; RestorePackagesHandler constructs the SNS store from FILE_FINALIZED_TOPIC_ARN. Nil scan-trigger is tolerated for local/test envs.
- lambda/restore/main.go: SNS client init.
- terraform/iam.tf: sns:Publish on the FileFinalized topic ARN (sourced from upload-service-v2's existing remote state).
- terraform/lambda.tf: FILE_FINALIZED_TOPIC_ARN env var on the restore Lambda.
- api/service/service_test.go: stub GetFilesNeedingRescanByPackageId on MockPackagesStore to satisfy the new interface method.

## Tests
- go build / go vet clean across api/, lambda/restore/, lambda/service/.
- TestMessageHandler_handleFilePackage extended: plumbs a fake SNSPublisher through NewBaseStore, asserts each scenario's restored files produce a FileFinalized event with the expected fileId, organizationId, s3Bucket, s3Key.
- [ ] make test-ci (needs docker-compose; please run before merge)
- [ ] Deploy to dev; restore a known-pending file; observe scan-service logs scan it cleanly

## Follow-ups
- **Slim FileFinalized contract.** scan-service struct still parses manifestId / complianceTier / fileType / extension / checksum / datasetId / timestamp / traceId — none are read. Coordinate a small cleanup PR across scan-service + upload-service-v2.
- **Scoped reconciler** (belt-and-suspenders) for any rows stuck at pending from causes other than restore (deploy gaps, DLQ losers post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)