### PR TITLE
Allow dataset-scoped viewer assets

### DIFF
--- a/doc/viewer-assets.md
+++ b/doc/viewer-assets.md
@@ -14,7 +14,9 @@ Dataset
 ```
 
 - A **viewer asset** belongs to exactly one **dataset**.
-- A viewer asset can be linked to **one or more packages** (many-to-many via a junction table).
+- A viewer asset can be linked to **zero or more packages** (many-to-many via a junction table).
+  - An asset with **one or more** package links is *package-scoped*: it visualises data from those specific packages.
+  - An asset with **zero** package links is *dataset-scoped*: it represents data at the dataset level (e.g. a cohort-wide UMAP). Scope is derived from the current state of the junction table — there is no `scope` column — and an asset can move between scopes by editing its `package_ids` via PATCH.
 - Each viewer asset maps to a set of files stored under a single S3 prefix.
 
 ### Database Tables
@@ -178,10 +180,15 @@ Create a viewer asset and receive temporary upload credentials.
 
 #### GET /packages/assets
 
-List viewer assets linked to a package.
+List viewer assets for a dataset. Operates in two modes:
+
+- **`package_id` supplied** — returns assets linked to that package (*package-scoped*).
+- **`package_id` omitted** — returns assets in the dataset that have **no package links** (*dataset-scoped*).
+
+Settings:
 
 - **Permission**: `ViewFiles`
-- **Query params**: `dataset_id` (required), `package_id` (required)
+- **Query params**: `dataset_id` (required), `package_id` (optional)
 - **Returns**: Array of assets (each with `asset_url`) plus CloudFront signing params
 
 #### PATCH /packages/assets/{asset_id}
@@ -204,11 +211,14 @@ Delete an asset record and queue its S3 objects for cleanup.
 
 #### GET /packages/discover/assets
 
-List viewer assets for a published package. No authentication required.
+List viewer assets for a published package or dataset. No authentication required.
 
-- **Query params**: `package_id` (required) — source package node ID
-- **Validation**: Checks the Discover database to confirm the package is published
+- **Query params**: exactly one of
+  - `package_id` — the **source package node ID** (e.g. `N:package:abc-123`). Returns assets linked to that package.
+  - `dataset_id` — the **published-dataset PK** as an integer, i.e. `discover.public_datasets.id` (the same numeric ID that appears in `https://discover.pennsieve.io/datasets/{id}` URLs). Returns dataset-scoped assets (those with no package links).
+- **Validation**: Checks the Discover database to confirm the package or dataset is published. Note the asymmetry: the package side accepts a *node ID* (because `discover.public_file_versions` stores `source_package_id` as a node ID), while the dataset side accepts the *published-dataset integer PK* (because `discover.public_datasets` does not store the source dataset node ID).
 - **Returns**: Array of assets (each with `asset_url`) plus CloudFront signing params
+- **Errors**: 400 if neither or both query params are supplied, or if `dataset_id` is non-numeric. 404 if the package/dataset is not published.
 
 ## Accessing Viewer Assets from the Front-End
 

--- a/lambda/service/handler/assets.go
+++ b/lambda/service/handler/assets.go
@@ -186,6 +186,9 @@ func (h *ViewerAssetsHandler) handleCreate(ctx context.Context) (*events.APIGate
 	return h.buildResponse(resp, http.StatusCreated)
 }
 
+// handleList returns viewer assets for a dataset, in one of two modes:
+//   - if package_id is supplied: assets linked to that package (package-scoped)
+//   - if package_id is absent:   assets with no package links (dataset-scoped)
 func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
 	if !authorizer.HasRole(*h.claims, permissions.ViewFiles) {
 		return h.logAndBuildError("unauthorized", http.StatusUnauthorized), nil
@@ -195,45 +198,52 @@ func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewa
 	datasetNodeID := h.queryParams["dataset_id"]
 	packageNodeID := h.queryParams["package_id"]
 
-	if packageNodeID == "" {
-		return h.logAndBuildError("package_id is required", http.StatusBadRequest), nil
-	}
-
 	datasetIntID, err := h.resolveDatasetID(ctx, orgID, datasetNodeID)
 	if err != nil {
 		return h.logAndBuildError(fmt.Sprintf("failed to resolve dataset: %v", err), http.StatusBadRequest), nil
 	}
 
-	packageIntID, err := h.resolvePackageID(ctx, orgID, packageNodeID, datasetIntID)
-	if err != nil {
-		return h.logAndBuildError(fmt.Sprintf("failed to resolve package: %v", err), http.StatusBadRequest), nil
+	if packageNodeID != "" {
+		packageIntID, err := h.resolvePackageID(ctx, orgID, packageNodeID, datasetIntID)
+		if err != nil {
+			return h.logAndBuildError(fmt.Sprintf("failed to resolve package: %v", err), http.StatusBadRequest), nil
+		}
+
+		query := fmt.Sprintf(`
+			SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
+			FROM "%d".%s va
+			JOIN "%d".%s vap ON va.id = vap.viewer_asset_id
+			WHERE vap.package_id = $1
+			ORDER BY va.created_at DESC
+		`, orgID, viewerAssetsTable, orgID, viewerAssetPackagesTable)
+
+		return h.runListQuery(ctx, orgID, datasetIntID, datasetNodeID, query, packageIntID)
 	}
 
 	query := fmt.Sprintf(`
 		SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
 		FROM "%d".%s va
-		JOIN "%d".%s vap ON va.id = vap.viewer_asset_id
-		WHERE vap.package_id = $1
+		WHERE va.dataset_id = $1
+		  AND NOT EXISTS (
+		    SELECT 1 FROM "%d".%s vap WHERE vap.viewer_asset_id = va.id
+		  )
 		ORDER BY va.created_at DESC
 	`, orgID, viewerAssetsTable, orgID, viewerAssetPackagesTable)
 
-	rows, err := PennsieveDB.QueryContext(ctx, query, packageIntID)
+	return h.runListQuery(ctx, orgID, datasetIntID, datasetNodeID, query, datasetIntID)
+}
+
+// runListQuery executes a viewer-assets list query, builds responses with per-asset
+// CloudFront URLs and signed-policy cookies, and serializes the result. Shared by
+// handleList (package-scoped) and handleListByDataset (dataset-scoped).
+func (h *ViewerAssetsHandler) runListQuery(ctx context.Context, orgID, datasetIntID int64, datasetNodeID, query string, arg interface{}) (*events.APIGatewayV2HTTPResponse, error) {
+	rows, err := PennsieveDB.QueryContext(ctx, query, arg)
 	if err != nil {
 		return h.logAndBuildError(fmt.Sprintf("failed to query assets: %v", err), http.StatusInternalServerError), nil
 	}
 	defer rows.Close()
 
-	// Build asset URL base: https://{domain}{pathPrefix}/O{orgID}/D{datasetID}/
-	var assetURLBase string
-	if cloudfrontDistributionDomain != "" {
-		cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
-		pathPrefix, _ := cfHandler.getOrganizationCloudFrontPath(ctx, orgID)
-		if pathPrefix != "" {
-			assetURLBase = fmt.Sprintf("https://%s%s/O%d/D%d/", cloudfrontDistributionDomain, pathPrefix, orgID, datasetIntID)
-		} else {
-			assetURLBase = fmt.Sprintf("https://%s/O%d/D%d/", cloudfrontDistributionDomain, orgID, datasetIntID)
-		}
-	}
+	assetURLBase := h.buildAssetURLBase(ctx, orgID, datasetIntID)
 
 	var assets []viewerAssetResponse
 	for rows.Next() {
@@ -266,31 +276,9 @@ func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewa
 	}
 
 	resp := listViewerAssetsResponse{Assets: assets}
-
-	// Load CloudFront signing keys from Secrets Manager if not yet cached
-	if cloudfrontDistributionDomain != "" && cloudfrontPrivateKey == nil {
-		if secretName, ok := os.LookupEnv("CLOUDFRONT_SIGNING_KEYS_SECRET_NAME"); ok {
-			cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
-			if err := cfHandler.loadKeysFromSecretsManager(ctx, secretName); err != nil {
-				h.logger.WithError(err).Warn("failed to load CloudFront signing keys")
-			}
-		}
-	}
-
-	// Generate CloudFront signed policy if signing keys are available
-	var cookies []string
-	if cloudfrontDistributionDomain != "" && cloudfrontPrivateKey != nil {
-		s3Prefix := fmt.Sprintf("O%d/D%d/", orgID, datasetIntID)
-		cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
-		signedURL, expiresAt, err := cfHandler.generateCloudFrontSignedURLWithPolicy(s3Prefix, "")
-		if err == nil {
-			components, err := cfHandler.extractURLComponents(signedURL, expiresAt, s3Prefix)
-			if err == nil {
-				resp.CloudFront = components
-				cookieDomain := "." + os.Getenv("PENNSIEVE_DOMAIN")
-				cookies = components.CloudFrontCookies(cookieDomain)
-			}
-		}
+	components, cookies := h.signDatasetCloudFront(ctx, orgID, datasetIntID)
+	if components != nil {
+		resp.CloudFront = components
 	}
 
 	apiResp, err := h.buildResponse(resp, http.StatusOK)
@@ -301,6 +289,53 @@ func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewa
 		apiResp.Cookies = cookies
 	}
 	return apiResp, nil
+}
+
+// buildAssetURLBase returns the CloudFront URL prefix for a dataset's assets
+// (e.g. "https://cdn/.../O{org}/D{dataset}/"), or "" when CloudFront is not configured.
+func (h *ViewerAssetsHandler) buildAssetURLBase(ctx context.Context, orgID, datasetIntID int64) string {
+	if cloudfrontDistributionDomain == "" {
+		return ""
+	}
+	cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
+	pathPrefix, _ := cfHandler.getOrganizationCloudFrontPath(ctx, orgID)
+	if pathPrefix != "" {
+		return fmt.Sprintf("https://%s%s/O%d/D%d/", cloudfrontDistributionDomain, pathPrefix, orgID, datasetIntID)
+	}
+	return fmt.Sprintf("https://%s/O%d/D%d/", cloudfrontDistributionDomain, orgID, datasetIntID)
+}
+
+// signDatasetCloudFront generates CloudFront signing components and cookies covering
+// every asset under O{org}/D{dataset}/. Returns (nil, nil) if signing is not configured
+// or fails — callers treat that as "no signing", not an error.
+func (h *ViewerAssetsHandler) signDatasetCloudFront(ctx context.Context, orgID, datasetIntID int64) (*CloudFrontURLComponents, []string) {
+	if cloudfrontDistributionDomain == "" {
+		return nil, nil
+	}
+	if cloudfrontPrivateKey == nil {
+		if secretName, ok := os.LookupEnv("CLOUDFRONT_SIGNING_KEYS_SECRET_NAME"); ok {
+			cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
+			if err := cfHandler.loadKeysFromSecretsManager(ctx, secretName); err != nil {
+				h.logger.WithError(err).Warn("failed to load CloudFront signing keys")
+			}
+		}
+	}
+	if cloudfrontPrivateKey == nil {
+		return nil, nil
+	}
+
+	s3Prefix := fmt.Sprintf("O%d/D%d/", orgID, datasetIntID)
+	cfHandler := CloudFrontSignedURLHandler{RequestHandler: h.RequestHandler}
+	signedURL, expiresAt, err := cfHandler.generateCloudFrontSignedURLWithPolicy(s3Prefix, "")
+	if err != nil {
+		return nil, nil
+	}
+	components, err := cfHandler.extractURLComponents(signedURL, expiresAt, s3Prefix)
+	if err != nil {
+		return nil, nil
+	}
+	cookieDomain := "." + os.Getenv("PENNSIEVE_DOMAIN")
+	return components, components.CloudFrontCookies(cookieDomain)
 }
 
 func (h *ViewerAssetsHandler) handleUpdate(ctx context.Context, assetID string) (*events.APIGatewayV2HTTPResponse, error) {

--- a/lambda/service/handler/assets_test.go
+++ b/lambda/service/handler/assets_test.go
@@ -117,11 +117,10 @@ func TestCreateViewerAsset_MissingFields(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
-func TestListViewerAssets_RequiresPackageID(t *testing.T) {
+func TestListViewerAssets_RequiresDatasetID(t *testing.T) {
 	setupAssetsTestDB(t)
 
-	req := newTestRequest("GET", "/assets", "list-no-pkg",
-		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	req := newTestRequest("GET", "/assets", "list-no-ds", nil, "")
 
 	resp, err := NewHandler(req, assetsViewerClaims()).WithDefaultService().handle(context.Background())
 	require.NoError(t, err)
@@ -246,3 +245,131 @@ func TestViewerAssetsFullLifecycle(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+// TestListViewerAssets_NoPackageID_ReturnsDatasetScoped verifies that GET /assets
+// with only dataset_id (no package_id) returns assets with no rows in
+// viewer_asset_packages.
+func TestListViewerAssets_NoPackageID_ReturnsDatasetScoped(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	createTestPackages(t, db, 2, 1)
+
+	// Asset A: linked to a package
+	var pkgScopedID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by)
+		VALUES (1, 'pkg-scoped', 'ome-zarr', '{}', 'test-storage-bucket', 101) RETURNING id`).Scan(&pkgScopedID)
+	require.NoError(t, err)
+	_, err = db.DB.Exec(`INSERT INTO "2".viewer_asset_packages (viewer_asset_id, package_id) VALUES ($1, 5001)`, pkgScopedID)
+	require.NoError(t, err)
+
+	// Asset B: no package links — dataset-scoped
+	var datasetScopedID string
+	err = db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by)
+		VALUES (1, 'dataset-scoped', 'parquet-umap-viewer', '{}', 'test-storage-bucket', 101) RETURNING id`).Scan(&datasetScopedID)
+	require.NoError(t, err)
+
+	req := newTestRequest("GET", "/assets", "list-dataset-scoped",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+
+	resp, err := NewHandler(req, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &result))
+	require.Len(t, result.Assets, 1)
+	assert.Equal(t, datasetScopedID, result.Assets[0].ID)
+	assert.Equal(t, "dataset-scoped", result.Assets[0].Name)
+	assert.Empty(t, result.Assets[0].PackageIDs)
+}
+
+// TestPatchPackageLinks_RemoveAll_BecomesDatasetScoped verifies that an asset
+// can transition from package-scoped to dataset-scoped via PATCH with an empty
+// package_ids array, and that subsequent list calls reflect the change.
+func TestPatchPackageLinks_RemoveAll_BecomesDatasetScoped(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	pkgNodeIDs := createTestPackages(t, db, 2, 1)
+
+	var assetID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by)
+		VALUES (1, 'transition-test', 'ome-zarr', '{}', 'test-storage-bucket', 101) RETURNING id`).Scan(&assetID)
+	require.NoError(t, err)
+	_, err = db.DB.Exec(`INSERT INTO "2".viewer_asset_packages (viewer_asset_id, package_id) VALUES ($1, 5001)`, assetID)
+	require.NoError(t, err)
+
+	// PATCH to empty package_ids
+	patchBody, _ := json.Marshal(updateViewerAssetRequest{PackageIDs: &[]string{}})
+	patchReq := newTestRequest("PATCH", "/assets/"+assetID, "patch-remove-all",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, string(patchBody))
+
+	patchResp, err := NewHandler(patchReq, assetsEditorClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patchResp.StatusCode)
+
+	var updated viewerAssetResponse
+	require.NoError(t, json.Unmarshal([]byte(patchResp.Body), &updated))
+	assert.Empty(t, updated.PackageIDs)
+
+	// Verify the asset now appears in dataset-scoped list
+	dsReq := newTestRequest("GET", "/assets", "list-ds-after",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	dsResp, err := NewHandler(dsReq, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, dsResp.StatusCode)
+
+	var dsResult listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(dsResp.Body), &dsResult))
+	require.Len(t, dsResult.Assets, 1)
+	assert.Equal(t, assetID, dsResult.Assets[0].ID)
+
+	// And no longer appears under the original package
+	pkgReq := newTestRequest("GET", "/assets", "list-by-pkg-after",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID, "package_id": pkgNodeIDs[0]}, "")
+	pkgResp, err := NewHandler(pkgReq, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, pkgResp.StatusCode)
+
+	var pkgResult listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(pkgResp.Body), &pkgResult))
+	assert.Empty(t, pkgResult.Assets)
+}
+
+// TestPatchPackageLinks_AddToEmpty_BecomesPackageScoped verifies the reverse
+// transition: a dataset-scoped asset becomes package-scoped when PATCHed with
+// non-empty package_ids.
+func TestPatchPackageLinks_AddToEmpty_BecomesPackageScoped(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	pkgNodeIDs := createTestPackages(t, db, 2, 1)
+
+	var assetID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by)
+		VALUES (1, 'add-links', 'ome-zarr', '{}', 'test-storage-bucket', 101) RETURNING id`).Scan(&assetID)
+	require.NoError(t, err)
+
+	patchBody, _ := json.Marshal(updateViewerAssetRequest{PackageIDs: &[]string{pkgNodeIDs[0]}})
+	patchReq := newTestRequest("PATCH", "/assets/"+assetID, "patch-add-links",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, string(patchBody))
+
+	patchResp, err := NewHandler(patchReq, assetsEditorClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patchResp.StatusCode)
+
+	var updated viewerAssetResponse
+	require.NoError(t, json.Unmarshal([]byte(patchResp.Body), &updated))
+	assert.Equal(t, []string{pkgNodeIDs[0]}, updated.PackageIDs)
+
+	// Dataset-scoped list should no longer include it
+	dsReq := newTestRequest("GET", "/assets", "list-ds-empty",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	dsResp, err := NewHandler(dsReq, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, dsResp.StatusCode)
+
+	var dsResult listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(dsResp.Body), &dsResult))
+	assert.Empty(t, dsResult.Assets)
+}
+

--- a/lambda/service/handler/discover_cloudfront.go
+++ b/lambda/service/handler/discover_cloudfront.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,38 +31,72 @@ func (h *DiscoverCloudFrontSignedURLHandler) handleOptions(ctx context.Context) 
 	}, nil
 }
 
-// handleListAssets lists viewer assets for a published package (unauthenticated).
+// handleListAssets lists viewer assets for a published package or dataset (unauthenticated).
+// Accepts exactly one of:
+//   - package_id: the source package node ID (returns assets linked to that package)
+//   - dataset_id: the published-dataset PK from discover.public_datasets.id (returns
+//     dataset-scoped assets — those with no package links)
 func (h *DiscoverCloudFrontSignedURLHandler) handleListAssets(ctx context.Context) (*events.APIGatewayV2HTTPResponse, error) {
 	packageNodeID := h.queryParams["package_id"]
-	if packageNodeID == "" {
-		return h.logAndBuildError("missing required 'package_id' query parameter", http.StatusBadRequest), nil
+	publishedDatasetIDStr := h.queryParams["dataset_id"]
+
+	if (packageNodeID == "") == (publishedDatasetIDStr == "") {
+		return h.logAndBuildError("exactly one of 'package_id' or 'dataset_id' is required", http.StatusBadRequest), nil
 	}
 
-	h.logger.WithField("packageId", packageNodeID).Info("handling GET request for discover viewer assets")
+	var (
+		orgID         int64
+		datasetIntID  int64
+		packageIntID  int64
+		datasetNodeID string
+		query         string
+		queryArg      interface{}
+		err           error
+	)
 
-	// Validate that the package is published and resolve IDs
-	orgID, datasetIntID, packageIntID, err := h.resolveDiscoverPackage(ctx, packageNodeID)
-	if err != nil {
-		return h.logAndBuildError(fmt.Sprintf("failed to resolve published package: %v", err), http.StatusNotFound), nil
+	if packageNodeID != "" {
+		h.logger.WithField("packageId", packageNodeID).Info("handling GET request for discover viewer assets")
+		orgID, datasetIntID, packageIntID, err = h.resolveDiscoverPackage(ctx, packageNodeID)
+		if err != nil {
+			return h.logAndBuildError(fmt.Sprintf("failed to resolve published package: %v", err), http.StatusNotFound), nil
+		}
+		query = fmt.Sprintf(`
+			SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
+			FROM "%d".viewer_assets va
+			JOIN "%d".viewer_asset_packages vap ON va.id = vap.viewer_asset_id
+			WHERE vap.package_id = $1
+			ORDER BY va.created_at DESC
+		`, orgID, orgID)
+		queryArg = packageIntID
+	} else {
+		publishedDatasetID, parseErr := strconv.ParseInt(publishedDatasetIDStr, 10, 64)
+		if parseErr != nil {
+			return h.logAndBuildError("'dataset_id' must be a positive integer (the published-dataset ID)", http.StatusBadRequest), nil
+		}
+		h.logger.WithField("publishedDatasetId", publishedDatasetID).Info("handling GET request for discover viewer assets by dataset")
+		orgID, datasetIntID, err = h.resolveDiscoverDataset(ctx, publishedDatasetID)
+		if err != nil {
+			return h.logAndBuildError(fmt.Sprintf("failed to resolve published dataset: %v", err), http.StatusNotFound), nil
+		}
+		query = fmt.Sprintf(`
+			SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
+			FROM "%d".viewer_assets va
+			WHERE va.dataset_id = $1
+			  AND NOT EXISTS (
+			    SELECT 1 FROM "%d".viewer_asset_packages vap WHERE vap.viewer_asset_id = va.id
+			  )
+			ORDER BY va.created_at DESC
+		`, orgID, orgID)
+		queryArg = datasetIntID
 	}
 
 	// Resolve dataset node ID for the response
-	var datasetNodeID string
 	dsQuery := fmt.Sprintf(`SELECT node_id FROM "%d".datasets WHERE id = $1`, orgID)
 	if err := PennsieveDB.QueryRowContext(ctx, dsQuery, datasetIntID).Scan(&datasetNodeID); err != nil {
 		return h.logAndBuildError(fmt.Sprintf("failed to resolve dataset node ID: %v", err), http.StatusInternalServerError), nil
 	}
 
-	// Query viewer assets linked to this package
-	query := fmt.Sprintf(`
-		SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
-		FROM "%d".viewer_assets va
-		JOIN "%d".viewer_asset_packages vap ON va.id = vap.viewer_asset_id
-		WHERE vap.package_id = $1
-		ORDER BY va.created_at DESC
-	`, orgID, orgID)
-
-	rows, err := PennsieveDB.QueryContext(ctx, query, packageIntID)
+	rows, err := PennsieveDB.QueryContext(ctx, query, queryArg)
 	if err != nil {
 		return h.logAndBuildError(fmt.Sprintf("failed to query assets: %v", err), http.StatusInternalServerError), nil
 	}
@@ -192,6 +227,28 @@ func (h *DiscoverCloudFrontSignedURLHandler) resolveDiscoverPackage(ctx context.
 	}
 
 	return orgID, datasetIntID, packageIntID, nil
+}
+
+// resolveDiscoverDataset validates that a dataset is published via the Discover DB
+// and returns the source org ID and source dataset integer ID.
+// publishedDatasetID is discover.public_datasets.id (the published-dataset PK).
+func (h *DiscoverCloudFrontSignedURLHandler) resolveDiscoverDataset(ctx context.Context, publishedDatasetID int64) (orgID, datasetIntID int64, err error) {
+	if DiscoverDB == nil {
+		return 0, 0, fmt.Errorf("discover database not configured")
+	}
+
+	discoverQuery := `
+		SELECT source_organization_id, source_dataset_id
+		FROM discover.public_datasets
+		WHERE id = $1
+	`
+	err = DiscoverDB.QueryRowContext(ctx, discoverQuery, publishedDatasetID).Scan(&orgID, &datasetIntID)
+	if err != nil {
+		h.logger.WithError(err).WithField("publishedDatasetId", publishedDatasetID).Error("failed to look up dataset in discover database")
+		return 0, 0, fmt.Errorf("published dataset not found")
+	}
+
+	return orgID, datasetIntID, nil
 }
 
 // generateDiscoverCloudFrontSignedURL generates a signed URL for a discover package.

--- a/lambda/service/handler/discover_cloudfront_test.go
+++ b/lambda/service/handler/discover_cloudfront_test.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscoverListAssets_RequiresExactlyOneOfPackageOrDataset verifies that the
+// public /discover/assets endpoint rejects requests that pass neither or both
+// of the package_id and dataset_id query parameters.
+func TestDiscoverListAssets_RequiresExactlyOneOfPackageOrDataset(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string]string
+	}{
+		{name: "neither", params: nil},
+		{name: "both", params: map[string]string{"package_id": "N:package:abc", "dataset_id": "42"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newTestRequest("GET", "/discover/assets", "discover-"+tc.name, tc.params, "")
+			handler := NewDiscoverHandler(req)
+			resp, err := handler.handleDiscover(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Contains(t, resp.Body, "exactly one")
+		})
+	}
+}
+
+// TestDiscoverListAssets_InvalidDatasetID verifies that a non-numeric dataset_id
+// is rejected with 400 before any DB lookup.
+func TestDiscoverListAssets_InvalidDatasetID(t *testing.T) {
+	req := newTestRequest("GET", "/discover/assets", "discover-bad-id",
+		map[string]string{"dataset_id": "not-a-number"}, "")
+	handler := NewDiscoverHandler(req)
+	resp, err := handler.handleDiscover(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, resp.Body, "positive integer")
+}

--- a/terraform/packages-service.yml
+++ b/terraform/packages-service.yml
@@ -132,14 +132,20 @@ paths:
 
   /discover/assets:
     get:
-      summary: List viewer assets for a published package
+      summary: List viewer assets for a published package or dataset
       description: |
-        Unauthenticated endpoint that returns viewer assets linked to a published
-        package along with a CloudFront signed policy for accessing the asset files.
-        Validates that the package is published via the Discover database.
-        Each asset includes an `asset_url`. To access files, append the relative
-        path and signing params:
+        Unauthenticated endpoint that returns viewer assets for a published
+        package or a published dataset, along with a CloudFront signed policy
+        for accessing the asset files. Each asset includes an `asset_url`.
+        To access files, append the relative path and signing params:
         `{asset_url}{path}?Policy={policy}&Signature={signature}&Key-Pair-Id={key_pair_id}`
+
+        Caller must supply **exactly one** of `package_id` or `dataset_id`.
+        Note the asymmetry between the two: the package side accepts a *node ID*
+        because `discover.public_file_versions` stores `source_package_id` as a
+        node ID, while the dataset side accepts the *published-dataset integer
+        PK* because `discover.public_datasets` does not record the source
+        dataset node ID.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
       operationId: discoverListViewerAssets
@@ -150,8 +156,21 @@ paths:
           name: package_id
           schema:
             type: string
-          required: true
-          description: source package node id (e.g. `N:package:uuid`)
+          required: false
+          description: |
+            Source package node id (e.g. `N:package:uuid`). Returns viewer assets
+            linked to that package. Mutually exclusive with `dataset_id`.
+        - in: query
+          name: dataset_id
+          schema:
+            type: integer
+            format: int64
+          required: false
+          description: |
+            Published-dataset integer PK (i.e. `discover.public_datasets.id`,
+            the same numeric ID used in `https://discover.pennsieve.io/datasets/{id}`
+            URLs). Returns dataset-scoped viewer assets (those with no package
+            links). Mutually exclusive with `package_id`.
       responses:
         '200':
           description: List of viewer assets with CloudFront access
@@ -206,12 +225,18 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
     get:
-      summary: List viewer assets for a package
+      summary: List viewer assets for a dataset or package
       description: |
-        Returns viewer assets linked to a package along with a CloudFront
-        signed policy for accessing the assets. Each asset includes an `asset_url`.
+        Returns viewer assets for a dataset, along with a CloudFront signed
+        policy for accessing the asset files. Each asset includes an `asset_url`.
         To access files, append the relative path and signing params:
         `{asset_url}{path}?Policy={policy}&Signature={signature}&Key-Pair-Id={key_pair_id}`
+
+        Operates in one of two modes depending on `package_id`:
+          - **package_id supplied** — returns assets linked to that package
+            (package-scoped assets).
+          - **package_id omitted** — returns assets in the dataset that have
+            no package links (dataset-scoped assets).
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
       operationId: listViewerAssets
@@ -230,8 +255,11 @@ paths:
           name: package_id
           schema:
             type: string
-          required: true
-          description: package node id
+          required: false
+          description: |
+            Optional package node id. When supplied, returns assets linked to
+            that package. When omitted, returns dataset-scoped assets (those
+            with no package links).
       responses:
         '200':
           description: List of viewer assets with CloudFront access


### PR DESCRIPTION
## Summary

- Viewer assets already carry `dataset_id` — only the API contract required every asset to have ≥1 package link. This change lifts that restriction so assets can exist purely at the dataset level (no `viewer_asset_packages` row).
- `GET /assets`: `package_id` is now **optional**. Supplied → package-scoped list (unchanged). Omitted → dataset-scoped list (`NOT EXISTS` against `viewer_asset_packages`). Scope is derived from junction-table state — no schema change, no `scope` column.
- `GET /discover/assets`: now accepts **exactly one** of `package_id` (source package node ID, unchanged) or `dataset_id` (the published-dataset PK, i.e. `discover.public_datasets.id`). The asymmetry between node ID and integer PK is forced by Discover's existing schema — `public_file_versions.source_package_id` is a node ID but `public_datasets` stores only the integer `source_dataset_id`.
- `POST /assets` already permits empty `package_ids`, so dataset-scoped asset creation works with no API change — clients just omit the array and use the returned STS credentials to upload to the same `viewer-assets/O{org}/D{dataset}/{assetID}/` prefix.

## Test plan

- [x] `go vet` and `go build` clean across `lambda/service/...`
- [x] New unit tests pass (`POSTGRES_HOST=localhost go test ./handler/...`):
  - `TestListViewerAssets_RequiresDatasetID` (replaces RequiresPackageID)
  - `TestListViewerAssets_NoPackageID_ReturnsDatasetScoped`
  - `TestPatchPackageLinks_RemoveAll_BecomesDatasetScoped`
  - `TestPatchPackageLinks_AddToEmpty_BecomesPackageScoped`
  - `TestDiscoverListAssets_RequiresExactlyOneOfPackageOrDataset`
  - `TestDiscoverListAssets_InvalidDatasetID`
- [x] Existing tests still pass (`TestViewerAssetsFullLifecycle`, auth tests).
- [ ] Manual smoke test in dev: POST `/assets` without `package_ids`, upload a file with returned STS creds, PATCH to `ready`, list via `GET /assets?dataset_id=…`.
- [ ] Manual smoke test of `GET /discover/assets?dataset_id=<published_id>` once a published dataset with dataset-scoped assets exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)