### PR TITLE
Add chat-session scope to viewer assets

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - $PWD:/go/src/github.com/pennsieve/packages-service
   pennsievedb:
-    image: pennsieve/pennsievedb:V20260420120100-seed
+    image: pennsieve/pennsievedb:V20260531120000-seed
     restart: always
   #    command: [ "postgres", "-c", "log_statement=all" ]
   minio:

--- a/lambda/service/handler/assets.go
+++ b/lambda/service/handler/assets.go
@@ -52,16 +52,22 @@ type viewerAssetRow struct {
 }
 
 type createViewerAssetRequest struct {
-	Name       string           `json:"name"`
-	AssetType  string           `json:"asset_type"`
-	Properties *json.RawMessage `json:"properties"`
-	PackageIDs []string         `json:"package_ids"`
+	Name          string           `json:"name"`
+	AssetType     string           `json:"asset_type"`
+	Properties    *json.RawMessage `json:"properties"`
+	PackageIDs    []string         `json:"package_ids"`
+	ChatSessionID *string          `json:"chat_session_id"`
 }
 
 type updateViewerAssetRequest struct {
 	Status     *string          `json:"status"`
 	Properties *json.RawMessage `json:"properties"`
 	PackageIDs *[]string        `json:"package_ids"`
+	// ClearChatSession, when true, detaches the asset from its chat session
+	// (chat_session_id = NULL) — i.e. "promote" the figure out of the chat so
+	// it becomes a normal dataset asset (and/or a package-linked one via
+	// PackageIDs). dataset_id is unchanged, so the bytes never move.
+	ClearChatSession *bool `json:"clear_chat_session"`
 }
 
 type uploadCredentialsResponse struct {
@@ -93,6 +99,11 @@ type createViewerAssetResponseBody struct {
 
 type listViewerAssetsResponse struct {
 	Assets     []viewerAssetResponse    `json:"assets"`
+	CloudFront *CloudFrontURLComponents `json:"cloudfront,omitempty"`
+}
+
+type getViewerAssetResponse struct {
+	Asset      viewerAssetResponse      `json:"asset"`
 	CloudFront *CloudFrontURLComponents `json:"cloudfront,omitempty"`
 }
 
@@ -139,16 +150,28 @@ func (h *ViewerAssetsHandler) handleCreate(ctx context.Context) (*events.APIGate
 		props = *req.Properties
 	}
 
+	// chat_session_id is optional; when set the figure is chat-scoped (excluded
+	// from the dataset listing) while its bytes still live under D{dataset}/.
+	cols := []string{"dataset_id", "name", "asset_type", "properties", "s3_bucket", "created_by"}
+	vals := []interface{}{datasetIntID, req.Name, req.AssetType, props, storageBucket, h.claims.UserClaim.Id}
+	if req.ChatSessionID != nil && *req.ChatSessionID != "" {
+		cols = append(cols, "chat_session_id")
+		vals = append(vals, *req.ChatSessionID)
+	}
+	placeholders := make([]string, len(vals))
+	for i := range vals {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+
 	var asset viewerAssetRow
 	insertQuery := fmt.Sprintf(`
-		INSERT INTO "%d".%s (dataset_id, name, asset_type, properties, s3_bucket, created_by)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO "%d".%s (%s)
+		VALUES (%s)
 		RETURNING id, dataset_id, name, asset_type, properties, s3_bucket, status, created_by, created_at
-	`, orgID, viewerAssetsTable)
+	`, orgID, viewerAssetsTable, strings.Join(cols, ", "), strings.Join(placeholders, ", "))
 
-	err = PennsieveDB.QueryRowContext(ctx, insertQuery,
-		datasetIntID, req.Name, req.AssetType, props, storageBucket, h.claims.UserClaim.Id,
-	).Scan(&asset.ID, &asset.DatasetID, &asset.Name, &asset.AssetType,
+	err = PennsieveDB.QueryRowContext(ctx, insertQuery, vals...).Scan(
+		&asset.ID, &asset.DatasetID, &asset.Name, &asset.AssetType,
 		&asset.Properties, &asset.S3Bucket, &asset.Status, &asset.CreatedBy, &asset.CreatedAt)
 	if err != nil {
 		h.logger.WithError(err).Error("failed to insert viewer asset")
@@ -224,6 +247,7 @@ func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewa
 		SELECT va.id, va.dataset_id, va.name, va.asset_type, va.properties, va.s3_bucket, va.status, va.created_at
 		FROM "%d".%s va
 		WHERE va.dataset_id = $1
+		  AND va.chat_session_id IS NULL
 		  AND NOT EXISTS (
 		    SELECT 1 FROM "%d".%s vap WHERE vap.viewer_asset_id = va.id
 		  )
@@ -231,6 +255,77 @@ func (h *ViewerAssetsHandler) handleList(ctx context.Context) (*events.APIGatewa
 	`, orgID, viewerAssetsTable, orgID, viewerAssetPackagesTable)
 
 	return h.runListQuery(ctx, orgID, datasetIntID, datasetNodeID, query, datasetIntID)
+}
+
+// handleGet resolves a single viewer asset by ID and returns it with a per-asset
+// CloudFront URL plus dataset-scoped signing cookies. Used by the frontend to
+// render inline chat figures (which are excluded from the dataset listing): the
+// caller has the asset ID (from the chat content block) and the dataset it lives
+// in. Authorization is dataset RBAC — the dataset cookie grants read to every
+// asset under O{org}/D{dataset}/, so no chat-session-specific check is needed.
+func (h *ViewerAssetsHandler) handleGet(ctx context.Context, assetID string) (*events.APIGatewayV2HTTPResponse, error) {
+	if !authorizer.HasRole(*h.claims, permissions.ViewFiles) {
+		return h.logAndBuildError("unauthorized", http.StatusUnauthorized), nil
+	}
+
+	orgID := h.claims.OrgClaim.IntId
+	datasetNodeID := h.queryParams["dataset_id"]
+
+	datasetIntID, err := h.resolveDatasetID(ctx, orgID, datasetNodeID)
+	if err != nil {
+		return h.logAndBuildError(fmt.Sprintf("failed to resolve dataset: %v", err), http.StatusBadRequest), nil
+	}
+
+	// Scope the lookup to the claimed dataset: that pairing is the authorization
+	// boundary (the caller proved dataset access via the dataset_id claim).
+	var a viewerAssetRow
+	query := fmt.Sprintf(`
+		SELECT id, dataset_id, name, asset_type, properties, s3_bucket, status, created_at
+		FROM "%d".%s WHERE id = $1 AND dataset_id = $2
+	`, orgID, viewerAssetsTable)
+	err = PennsieveDB.QueryRowContext(ctx, query, assetID, datasetIntID).Scan(
+		&a.ID, &a.DatasetID, &a.Name, &a.AssetType, &a.Properties, &a.S3Bucket, &a.Status, &a.CreatedAt)
+	if err == sql.ErrNoRows {
+		return h.logAndBuildError("asset not found", http.StatusNotFound), nil
+	}
+	if err != nil {
+		return h.logAndBuildError(fmt.Sprintf("failed to fetch asset: %v", err), http.StatusInternalServerError), nil
+	}
+
+	pkgIDs, _ := h.getLinkedPackageNodeIDs(ctx, orgID, a.ID)
+
+	var assetURL string
+	if assetURLBase := h.buildAssetURLBase(ctx, orgID, datasetIntID); assetURLBase != "" {
+		assetURL = assetURLBase + a.ID + "/"
+	}
+
+	resp := getViewerAssetResponse{
+		Asset: viewerAssetResponse{
+			ID:         a.ID,
+			DatasetID:  datasetNodeID,
+			Name:       a.Name,
+			AssetType:  a.AssetType,
+			AssetURL:   assetURL,
+			Properties: &a.Properties,
+			Status:     a.Status,
+			PackageIDs: pkgIDs,
+			CreatedAt:  a.CreatedAt.Format(time.RFC3339),
+		},
+	}
+
+	components, cookies := h.signDatasetCloudFront(ctx, orgID, datasetIntID)
+	if components != nil {
+		resp.CloudFront = components
+	}
+
+	apiResp, err := h.buildResponse(resp, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	if len(cookies) > 0 {
+		apiResp.Cookies = cookies
+	}
+	return apiResp, nil
 }
 
 // runListQuery executes a viewer-assets list query, builds responses with per-asset
@@ -370,6 +465,11 @@ func (h *ViewerAssetsHandler) handleUpdate(ctx context.Context, assetID string) 
 		setClauses = append(setClauses, fmt.Sprintf("properties = $%d", argIdx))
 		args = append(args, *req.Properties)
 		argIdx++
+	}
+	// Promote out of chat: detach the chat session. dataset_id stays set, so
+	// viewer_assets_scope_check holds and the bytes never move.
+	if req.ClearChatSession != nil && *req.ClearChatSession {
+		setClauses = append(setClauses, "chat_session_id = NULL")
 	}
 
 	if len(setClauses) > 0 {

--- a/lambda/service/handler/assets_test.go
+++ b/lambda/service/handler/assets_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -67,6 +68,7 @@ func setupAssetsTestDB(t *testing.T) *store.TestDB {
 		PennsieveDB = originalDB
 		db.DB.Exec(`DELETE FROM "2".viewer_asset_packages`)
 		db.DB.Exec(`DELETE FROM "2".viewer_assets`)
+		db.DB.Exec(`DELETE FROM "2".chat_sessions`)
 		db.Truncate(2, "packages")
 		db.Truncate(2, "datasets")
 		db.Close()
@@ -74,6 +76,20 @@ func setupAssetsTestDB(t *testing.T) *store.TestDB {
 
 	return db
 }
+
+// createTestChatSession inserts a chat_sessions row so chat-scoped viewer
+// assets have a valid chat_session_id FK target. Returns the session UUID.
+func createTestChatSession(t *testing.T, db *store.TestDB, orgID, datasetID int) string {
+	t.Helper()
+	var id string
+	err := db.DB.QueryRow(fmt.Sprintf(`
+		INSERT INTO "%d".chat_sessions (user_id, dataset_id, compute_node_id)
+		VALUES (101, $1, 'test-compute-node') RETURNING id`, orgID), datasetID).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func boolPtr(b bool) *bool { return &b }
 
 func createTestPackages(t *testing.T, db *store.TestDB, orgID int, datasetID int) []string {
 	t.Helper()
@@ -371,5 +387,135 @@ func TestPatchPackageLinks_AddToEmpty_BecomesPackageScoped(t *testing.T) {
 	var dsResult listViewerAssetsResponse
 	require.NoError(t, json.Unmarshal([]byte(dsResp.Body), &dsResult))
 	assert.Empty(t, dsResult.Assets)
+}
+
+// TestListViewerAssets_ExcludesChatScoped verifies a chat-scoped asset
+// (chat_session_id set) is excluded from the dataset-scoped listing, while a
+// plain dataset-scoped asset still appears.
+func TestListViewerAssets_ExcludesChatScoped(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	sessionID := createTestChatSession(t, db, 2, 1)
+
+	// Chat-scoped asset
+	var chatAssetID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by, chat_session_id)
+		VALUES (1, 'chat-figure', 'png', '{}', 'test-storage-bucket', 101, $1) RETURNING id`, sessionID).Scan(&chatAssetID)
+	require.NoError(t, err)
+
+	// Plain dataset-scoped asset
+	var dsAssetID string
+	err = db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by)
+		VALUES (1, 'dataset-figure', 'ome-zarr', '{}', 'test-storage-bucket', 101) RETURNING id`).Scan(&dsAssetID)
+	require.NoError(t, err)
+
+	req := newTestRequest("GET", "/assets", "list-excl-chat",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	resp, err := NewHandler(req, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &result))
+	require.Len(t, result.Assets, 1)
+	assert.Equal(t, dsAssetID, result.Assets[0].ID)
+}
+
+// TestGetViewerAsset_ByID verifies a single asset is resolvable by ID via
+// GET /assets/{id}, including a chat-scoped one that is hidden from the list.
+func TestGetViewerAsset_ByID(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	sessionID := createTestChatSession(t, db, 2, 1)
+
+	var assetID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by, chat_session_id)
+		VALUES (1, 'chat-figure', 'png', '{}', 'test-storage-bucket', 101, $1) RETURNING id`, sessionID).Scan(&assetID)
+	require.NoError(t, err)
+
+	req := newTestRequest("GET", "/assets/"+assetID, "get-by-id",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	resp, err := NewHandler(req, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result getViewerAssetResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &result))
+	assert.Equal(t, assetID, result.Asset.ID)
+	assert.Equal(t, "chat-figure", result.Asset.Name)
+}
+
+// TestGetViewerAsset_NotFound verifies an unknown asset ID returns 404.
+func TestGetViewerAsset_NotFound(t *testing.T) {
+	setupAssetsTestDB(t)
+
+	req := newTestRequest("GET", "/assets/00000000-0000-0000-0000-000000000000", "get-missing",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	resp, err := NewHandler(req, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestGetViewerAsset_Unauthorized verifies viewer-role is required.
+func TestGetViewerAsset_Unauthorized(t *testing.T) {
+	setupAssetsTestDB(t)
+
+	claims := &authorizer.Claims{
+		OrgClaim:     &organization.Claim{IntId: assetsTestOrgID},
+		UserClaim:    &user.Claim{Id: 101, NodeId: "N:user:test-101"},
+		DatasetClaim: &dataset.Claim{Role: role.None, NodeId: assetsTestDatasetNodeID, IntId: 1},
+	}
+	req := newTestRequest("GET", "/assets/some-uuid", "get-unauth",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	resp, err := NewHandler(req, claims).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestPatchClearChatSession_PromotesToDataset verifies that PATCH with
+// clear_chat_session=true detaches a chat figure so it becomes a normal
+// dataset-scoped asset (now visible in the dataset listing).
+func TestPatchClearChatSession_PromotesToDataset(t *testing.T) {
+	db := setupAssetsTestDB(t)
+	sessionID := createTestChatSession(t, db, 2, 1)
+
+	var assetID string
+	err := db.DB.QueryRow(`
+		INSERT INTO "2".viewer_assets (dataset_id, name, asset_type, properties, s3_bucket, created_by, chat_session_id)
+		VALUES (1, 'promote-me', 'png', '{}', 'test-storage-bucket', 101, $1) RETURNING id`, sessionID).Scan(&assetID)
+	require.NoError(t, err)
+
+	// Initially excluded from the dataset listing.
+	listReq := newTestRequest("GET", "/assets", "list-before-promote",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	listResp, err := NewHandler(listReq, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	var before listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(listResp.Body), &before))
+	assert.Empty(t, before.Assets)
+
+	// Promote: clear the chat session.
+	patchBody, _ := json.Marshal(updateViewerAssetRequest{ClearChatSession: boolPtr(true)})
+	patchReq := newTestRequest("PATCH", "/assets/"+assetID, "patch-promote",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, string(patchBody))
+	patchResp, err := NewHandler(patchReq, assetsEditorClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patchResp.StatusCode)
+
+	// chat_session_id is now NULL in the DB.
+	var chatSessionID sql.NullString
+	require.NoError(t, db.DB.QueryRow(`SELECT chat_session_id FROM "2".viewer_assets WHERE id = $1`, assetID).Scan(&chatSessionID))
+	assert.False(t, chatSessionID.Valid)
+
+	// Now visible in the dataset listing.
+	listReq2 := newTestRequest("GET", "/assets", "list-after-promote",
+		map[string]string{"dataset_id": assetsTestDatasetNodeID}, "")
+	listResp2, err := NewHandler(listReq2, assetsViewerClaims()).WithDefaultService().handle(context.Background())
+	require.NoError(t, err)
+	var after listViewerAssetsResponse
+	require.NoError(t, json.Unmarshal([]byte(listResp2.Body), &after))
+	require.Len(t, after.Assets, 1)
+	assert.Equal(t, assetID, after.Assets[0].ID)
 }
 

--- a/lambda/service/handler/root.go
+++ b/lambda/service/handler/root.go
@@ -41,6 +41,8 @@ func (h *RequestHandler) handle(ctx context.Context) (*events.APIGatewayV2HTTPRe
 			assetID := strings.TrimPrefix(h.path, "/assets/")
 			assetsHandler := ViewerAssetsHandler{RequestHandler: *h}
 			switch h.method {
+			case http.MethodGet:
+				return assetsHandler.handleGet(ctx, assetID)
 			case http.MethodPatch:
 				return assetsHandler.handleUpdate(ctx, assetID)
 			case http.MethodDelete:

--- a/terraform/packages-service.yml
+++ b/terraform/packages-service.yml
@@ -236,7 +236,9 @@ paths:
           - **package_id supplied** — returns assets linked to that package
             (package-scoped assets).
           - **package_id omitted** — returns assets in the dataset that have
-            no package links (dataset-scoped assets).
+            no package links and no chat session (dataset-scoped assets).
+            Chat-scoped figures are excluded; resolve them individually via
+            `GET /assets/{asset_id}`.
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
       operationId: listViewerAssets
@@ -273,6 +275,49 @@ paths:
           $ref: '#/components/responses/Error'
 
   /assets/{asset_id}:
+    get:
+      summary: Get a single viewer asset by ID
+      description: |
+        Resolves one viewer asset by its UUID and returns it with a CloudFront
+        signed policy for accessing the asset's files (same `asset_url` +
+        `cloudfront` signing model as the list endpoint). Used to render assets
+        that are hidden from the dataset listing — notably chat-scoped figures.
+        Authorization is dataset RBAC: the asset must belong to the dataset in
+        the `dataset_id` claim.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/packages-service'
+      operationId: getViewerAsset
+      security:
+        - token_dataset_auth: [ ]
+      tags:
+        - Viewer Assets
+      parameters:
+        - in: path
+          name: asset_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: viewer asset UUID
+        - in: query
+          name: dataset_id
+          schema:
+            type: string
+          required: true
+          description: dataset node id
+      responses:
+        '200':
+          description: Viewer asset with CloudFront access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getViewerAssetResponse'
+        '404':
+          description: Asset not found
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
     patch:
       summary: Update a viewer asset
       description: |
@@ -531,6 +576,13 @@ components:
           items:
             type: string
           description: Package node IDs to attach the asset to
+        chat_session_id:
+          type: string
+          format: uuid
+          description: |
+            Optional chat session UUID. When set, the asset is chat-scoped:
+            excluded from the dataset asset listing and cascade-deleted when the
+            chat session is deleted. Its bytes still live under the dataset prefix.
 
     createViewerAssetResponse:
       type: object
@@ -586,6 +638,13 @@ components:
           type: array
           items:
             type: string
+        clear_chat_session:
+          type: boolean
+          description: |
+            When true, detaches the asset from its chat session
+            (chat_session_id is cleared) — "promotes" the figure out of the chat
+            so it becomes a normal dataset asset. The dataset is unchanged, so
+            the underlying S3 bytes never move.
 
     uploadCredentials:
       type: object
@@ -613,6 +672,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/viewerAsset'
+        cloudfront:
+          $ref: '#/components/schemas/cloudfrontURLComponents'
+
+    getViewerAssetResponse:
+      type: object
+      properties:
+        asset:
+          $ref: '#/components/schemas/viewerAsset'
         cloudfront:
           $ref: '#/components/schemas/cloudfrontURLComponents'
 


### PR DESCRIPTION
## Summary
Threads `chat_session_id` through the viewer-assets API so figures generated in a chat can be tracked, hidden from the dataset listing, resolved individually, and **promoted** out of the chat — without ever moving bytes or touching the underlying package.

- `handleCreate` accepts an optional `chat_session_id` (marks the figure chat-scoped).
- `handleList` excludes chat-linked assets from the dataset-scoped listing (mirrors the existing package-linked exclusion).
- **New `GET /assets/{id}`** resolves a single asset by ID with a dataset-scoped CloudFront cookie — used by the frontend to render inline chat figures that are intentionally hidden from the list. Authorization is dataset RBAC (`ViewFiles`).
- `handleUpdate` accepts `clear_chat_session` to detach a figure from its chat ("promote"); `dataset_id` is unchanged, so bytes never move.

## Design
- Bytes stay **D-keyed** (`viewer-assets/O{org}/D{dataset}/{id}/`). Chat scope is a metadata + lifecycle concern: deleting a chat session cascade-deletes its figures via the `chat_session_id` FK, and the (corrected, D-keyed) cleanup trigger reclaims each figure's S3 prefix.
- Deleting a chat figure removes **only** the viewer-asset; the package association (`viewer_asset_packages`) and the package itself are untouched.

## Dependencies
- Requires the `chat_session_id` column on `viewer_assets` (db-migrations PR #9, merged) and the corrective D-keyed cleanup trigger (db-migrations PR #10).
- Bumps the test seed image to `V20260531120000-seed`.

## Test plan
- [x] `make test MODULES="lambda/service"` passes against `V20260531120000-seed`.
- [x] New tests: chat-scoped exclusion from list, GET by ID (incl. hidden chat figure), 404, unauthorized, and clear_chat_session promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)