### PR TITLE
Tentative fix for the /packages/formats endpoint

### DIFF
--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -165,6 +165,9 @@ func buildResponseFromString(body string, status int) *events.APIGatewayV2HTTPRe
 	response := events.APIGatewayV2HTTPResponse{
 		Body:       body,
 		StatusCode: status,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 	return &response
 }


### PR DESCRIPTION
Added the string formatter to return the application/json response.